### PR TITLE
No unused imports

### DIFF
--- a/lib/rules/best-practises/index.js
+++ b/lib/rules/best-practises/index.js
@@ -8,6 +8,7 @@ const PayableFallbackChecker = require('./payable-fallback')
 const ReasonStringChecker = require('./reason-string')
 const NoConsoleLogChecker = require('./no-console')
 const NoGlobalImportsChecker = require('./no-global-import')
+const NoUnusedImportsChecker = require('./no-unused-import')
 
 module.exports = function checkers(reporter, config, inputSrc) {
   return [
@@ -21,5 +22,6 @@ module.exports = function checkers(reporter, config, inputSrc) {
     new ReasonStringChecker(reporter, config),
     new NoConsoleLogChecker(reporter),
     new NoGlobalImportsChecker(reporter),
+    new NoUnusedImportsChecker(reporter),
   ]
 }

--- a/lib/rules/best-practises/no-unused-import.js
+++ b/lib/rules/best-practises/no-unused-import.js
@@ -52,9 +52,13 @@ class NoUnusedImportsChecker extends BaseChecker {
   }
 
   ImportDirective(node) {
-    node.symbolAliasesIdentifiers.forEach((it) => {
-      this.importedNames[(it[1] || it[0]).name] = { node: it[0], used: false }
-    })
+    if (node.unitAlias) {
+      this.importedNames[node.unitAlias] = { node: node.unitAliasIdentifier, used: false }
+    } else {
+      node.symbolAliasesIdentifiers.forEach((it) => {
+        this.importedNames[(it[1] || it[0]).name] = { node: it[0], used: false }
+      })
+    }
   }
 
   VariableDeclaration(node) {

--- a/lib/rules/best-practises/no-unused-import.js
+++ b/lib/rules/best-practises/no-unused-import.js
@@ -1,0 +1,87 @@
+const { forIn } = require('lodash')
+const BaseChecker = require('../base-checker')
+
+const ruleId = 'no-unused-import'
+const meta = {
+  type: 'best-practises',
+
+  docs: {
+    description: 'Imported name is not used',
+    category: 'Best Practise Rules',
+  },
+
+  isDefault: false,
+  recommended: false,
+  defaultSetup: 'warn',
+
+  schema: null,
+}
+
+class NoUnusedImportsChecker extends BaseChecker {
+  constructor(reporter) {
+    super(reporter, ruleId, meta)
+    this.importedNames = {}
+  }
+
+  registerUsage(rawName) {
+    if (!rawName) return
+    // '.' is always a separator of names, and the first one is the one that
+    // was imported
+    const name = rawName.split('.')[0]
+    // if the key isn't set, then it's not a name that has been imported so we
+    // don't care about it
+    if (this.importedNames[name]) {
+      this.importedNames[name].used = true
+    }
+  }
+
+  MemberAccess(node) {
+    this.registerUsage(node.expression.name)
+  }
+
+  ArrayTypeName(node) {
+    this.registerUsage(node.baseTypeName.namePath)
+  }
+
+  NewExpression(node) {
+    this.registerUsage(node.typeName.namePath)
+  }
+
+  FunctionCall(node) {
+    this.registerUsage(node.expression.name)
+  }
+
+  ImportDirective(node) {
+    node.symbolAliasesIdentifiers.forEach((it) => {
+      this.importedNames[(it[1] || it[0]).name] = { node: it[0], used: false }
+    })
+  }
+
+  VariableDeclaration(node) {
+    // this ignores builtin types, the check inside registerUsage ignores types
+    // defined in the same file
+    if (node.typeName.type === 'UserDefinedTypeName') {
+      this.registerUsage(node.typeName.namePath)
+    }
+  }
+
+  ContractDefinition(node) {
+    node.baseContracts.forEach((inheritanceSpecifier) => {
+      this.registerUsage(inheritanceSpecifier.baseName.namePath)
+    })
+  }
+
+  UsingForDeclaration(node) {
+    this.registerUsage(node.libraryName)
+  }
+
+  'SourceUnit:exit'() {
+    forIn(this.importedNames, (value, key) => {
+      if (!value.used) {
+        this.error(value.node, `imported name ${key} is not used`)
+      }
+    })
+  }
+}
+
+module.exports = NoUnusedImportsChecker

--- a/lib/rules/best-practises/no-unused-import.js
+++ b/lib/rules/best-practises/no-unused-import.js
@@ -11,7 +11,7 @@ const meta = {
   },
 
   isDefault: false,
-  recommended: false,
+  recommended: true,
   defaultSetup: 'warn',
 
   schema: null,

--- a/lib/rules/best-practises/no-unused-import.js
+++ b/lib/rules/best-practises/no-unused-import.js
@@ -77,6 +77,7 @@ class NoUnusedImportsChecker extends BaseChecker {
 
   UsingForDeclaration(node) {
     this.registerUsage(node.libraryName)
+    node.functions.forEach((it) => this.registerUsage(it))
   }
 
   'SourceUnit:exit'() {

--- a/test/rules/best-practises/no-unused-import.js
+++ b/test/rules/best-practises/no-unused-import.js
@@ -17,6 +17,16 @@ describe('Linter - no-unused-import', () => {
     assertErrorMessage(report, 'imported name A is not used')
   })
 
+  it('should raise when name created in import "path" as name is not used', () => {
+    const code = `import './A.sol' as A;`
+
+    const report = linter.processStr(code, {
+      rules: { 'no-unused-import': 'error' },
+    })
+    assertErrorCount(report, 1)
+    assertErrorMessage(report, 'imported name A is not used')
+  })
+
   it('should raise error when using solhint:recommended', () => {
     const code = `pragma solidity ^0.5.8; import {A} from "./A.sol";`
 

--- a/test/rules/best-practises/no-unused-import.js
+++ b/test/rules/best-practises/no-unused-import.js
@@ -1,0 +1,136 @@
+const linter = require('../../../lib/index')
+const { assertNoErrors, assertErrorMessage, assertErrorCount } = require('../../common/asserts')
+
+describe('Linter - no-unused-import', () => {
+  it('should raise when imported name is not used', () => {
+    const code = `import {A} from './A.sol';`
+
+    const report = linter.processStr(code, {
+      rules: { 'no-unused-import': 'error' },
+    })
+    assertErrorCount(report, 1)
+    assertErrorMessage(report, 'imported name A is not used')
+  })
+
+  it('should report correct name when unused import is aliased', () => {
+    const code = `import {A as B} from './A.sol';`
+
+    const report = linter.processStr(code, {
+      rules: { 'no-unused-import': 'error' },
+    })
+    assertErrorCount(report, 1)
+    assertErrorMessage(report, 'imported name B is not used')
+  })
+
+  it('should raise when some of the imported names are not used', () => {
+    const code = `import {A, B} from './A.sol'; contract C is A {}`
+
+    const report = linter.processStr(code, {
+      rules: { 'no-unused-import': 'error' },
+    })
+    assertErrorCount(report, 1)
+    assertErrorMessage(report, 'imported name B is not used')
+  })
+
+  it('should not raise when contract name is used as a type for a memory variable', () => {
+    const code = `
+    import {ERC20} from './ERC20.sol';
+    contract A {
+      function fun () public {
+        ERC20 funToken = address(0);
+      }
+    }`
+
+    const report = linter.processStr(code, {
+      rules: { 'no-unused-import': 'error' },
+    })
+    assertNoErrors(report)
+  })
+  ;[
+    {
+      description: 'a field of an imported name is used',
+      code: `import {Vm} from './Vm.sol';
+            contract A {
+              function fun () public {
+                Vm.cheat('code');
+              }
+            }`,
+    },
+    {
+      description: 'imported name is used in new statement',
+      code: `import {OtherContract} from './Contract.sol';
+            contract Factory {
+              function deploy () public returns (address){
+                return new OtherContract();
+              }
+            }`,
+    },
+    {
+      description: 'imported name is used in array definition',
+      code: `import {B} from './Contract.sol';
+            contract A {
+              function fun () public {
+                B[] memory someArray;
+              }
+            }`,
+    },
+    {
+      description: 'member of imported name is used in array definition',
+      code: `import {B} from './Contract.sol';
+            contract A {
+              function fun () public {
+                B.field[] memory someArray;
+              }
+            }`,
+    },
+    {
+      description: 'imported name is used in type cast',
+      code: `import {ImportedType} from './Contract.sol';
+            contract A {
+              function fun () public {
+                ImportedType(address(0));
+              }
+            }`,
+    },
+    {
+      description: 'imported name is used as a custom error',
+      code: `import {SpecialError} from './Contract.sol';
+            contract A {
+              function fun () public {
+                revert SpecialError();
+              }
+            }`,
+    },
+    {
+      description: 'contract name is used for inheritance',
+      code: `import {A} from './A.sol'; contract B is A {}`,
+    },
+    {
+      description: 'aliased contract name is used',
+      code: `import {A as B} from './A.sol'; contract C is B {}`,
+    },
+    {
+      description: 'libary name is used in a using ... for statement',
+      code: `import {A} from './A.sol'; contract B { using A for uint256; }`,
+    },
+    {
+      description: 'contract name is used in a state variable declaration',
+      code: ` import {A} from './A.sol'; contract B { A public statevar; }`,
+    },
+    {
+      description: 'imported subtype is used in a state variable declaration',
+      code: `import {A} from './A.sol'; contract B { A.thing public statevar; }`,
+    },
+    {
+      description: 'imported type is used in a function parameter declaration',
+      code: `import {A} from './A.sol'; contract B { function (A.thing statevar) public {} }`,
+    },
+  ].forEach(({ description, code }) => {
+    it(`should not raise when ${description}`, () => {
+      const report = linter.processStr(code, {
+        rules: { 'no-unused-import': 'error' },
+      })
+      assertNoErrors(report)
+    })
+  })
+})

--- a/test/rules/best-practises/no-unused-import.js
+++ b/test/rules/best-practises/no-unused-import.js
@@ -1,5 +1,10 @@
 const linter = require('../../../lib/index')
-const { assertNoErrors, assertErrorMessage, assertErrorCount } = require('../../common/asserts')
+const {
+  assertNoErrors,
+  assertErrorMessage,
+  assertErrorCount,
+  assertWarnsCount,
+} = require('../../common/asserts')
 
 describe('Linter - no-unused-import', () => {
   it('should raise when imported name is not used', () => {
@@ -9,6 +14,16 @@ describe('Linter - no-unused-import', () => {
       rules: { 'no-unused-import': 'error' },
     })
     assertErrorCount(report, 1)
+    assertErrorMessage(report, 'imported name A is not used')
+  })
+
+  it('should raise error when using solhint:recommended', () => {
+    const code = `pragma solidity ^0.5.8; import {A} from "./A.sol";`
+
+    const report = linter.processStr(code, {
+      extends: 'solhint:recommended',
+    })
+    assertWarnsCount(report, 1)
     assertErrorMessage(report, 'imported name A is not used')
   })
 

--- a/test/rules/best-practises/no-unused-import.js
+++ b/test/rules/best-practises/no-unused-import.js
@@ -150,6 +150,23 @@ describe('Linter - no-unused-import', () => {
       description: 'imported type is used in a function parameter declaration',
       code: `import {A} from './A.sol'; contract B { function (A.thing statevar) public {} }`,
     },
+    {
+      description: 'imported function is attached to a type',
+      code: `import {add} from './A.sol'; type Int is int; using {add} for Int global;`,
+    },
+    {
+      description: 'imported function is used as a user-defined operator',
+      code: `import {add} from './A.sol'; type Int is int; using {add as +} for Int global;`,
+    },
+    {
+      description: 'field of imported name is attached to a type',
+      code: `
+          import {Int, Math} from "./A.sol"; using {Math.add} for Int;
+          contract C {
+              Int public foo;
+          }
+      `,
+    },
   ].forEach(({ description, code }) => {
     it(`should not raise when ${description}`, () => {
       const report = linter.processStr(code, {


### PR DESCRIPTION
I've modified both [openzeppelin-contracts](https://github.com/openzeppelin/openzeppelin-contracts) and [exactly](https://github.com/exactly/protocol) to manually add this rule and check for false positives, couldn't find any in the current implementation. However, I'm concerned I might be forgetting to register some usage regarding inline assembly or some other less-used feature, so feedback is of course appreciated on that.

as always, see git history for details.
