### PR TITLE
Fix false positives in no-unused-imports

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -15,7 +15,7 @@ title:       "Rule Index of Solhint"
 | [no-console](./rules/best-practises/no-console.md)                 | No console.log/logInt/logBytesX/logString/etc & No hardhat and forge-std console.sol import statements                | ✔️          |
 | [no-empty-blocks](./rules/best-practises/no-empty-blocks.md)       | Code block has zero statements inside. Some common exceptions apply.                                                  | ✔️          |
 | [no-global-import](./rules/best-practises/no-global-import.md)     | Import statement includes an entire file instead of selected symbols                                                  | ✔️          |
-| [no-unused-import](./rules/best-practises/no-unused-import.md)     | Imported name is not used                                                                                             | ✔️          |
+| [no-unused-import](./rules/best-practises/no-unused-import.md)     | Reports a warning when an imported name is not used                                                                   | ✔️          |
 | [no-unused-vars](./rules/best-practises/no-unused-vars.md)         | Variable "name" is unused.                                                                                            | ✔️          |
 | [payable-fallback](./rules/best-practises/payable-fallback.md)     | When fallback is not payable you will not be able to receive ethers.                                                  | ✔️          |
 | [reason-string](./rules/best-practises/reason-string.md)           | Require or revert statement must have a reason string and check that each reason string is at most N characters long. | ✔️          |

--- a/docs/rules/best-practises/no-unused-import.md
+++ b/docs/rules/best-practises/no-unused-import.md
@@ -12,7 +12,7 @@ title:       "no-unused-import | Solhint"
 
 
 ## Description
-Imported name is not used
+Reports a warning when an imported name is not used
 
 ## Options
 This rule accepts a string option of rule severity. Must be one of "error", "warn", "off". Default to warn.
@@ -28,10 +28,30 @@ This rule accepts a string option of rule severity. Must be one of "error", "war
 
 
 ## Examples
-This rule does not have examples.
+### 👍 Examples of **correct** code for this rule
+
+#### Imported name is used
+
+```solidity
+
+            import {A} from './A.sol';
+            contract B is A {}
+          
+```
+
+### 👎 Examples of **incorrect** code for this rule
+
+#### Imported name is not used
+
+```solidity
+
+            import {A} from './A.sol';
+            contract B {}
+          
+```
 
 ## Version
-This rule is introduced in the latest version.
+This rule was introduced in [Solhint 3.5.1](https://github.com/solhint-community/solhint-community/tree/v3.5.1)
 
 ## Resources
 - [Rule source](https://github.com/solhint-community/solhint-community/tree/master/lib/rules/best-practises/no-unused-import.js)

--- a/lib/rules/best-practises/no-unused-import.js
+++ b/lib/rules/best-practises/no-unused-import.js
@@ -17,6 +17,11 @@ const meta = {
   schema: null,
 }
 
+// meant to skip Identifiers that are part of the ImportDirective that defines a name
+function isImportIdentifier(node) {
+  return !node.parent || node.parent.type === 'ImportDirective'
+}
+
 class NoUnusedImportsChecker extends BaseChecker {
   constructor(reporter) {
     super(reporter, ruleId, meta)
@@ -35,10 +40,6 @@ class NoUnusedImportsChecker extends BaseChecker {
     }
   }
 
-  MemberAccess(node) {
-    this.registerUsage(node.expression.name)
-  }
-
   ArrayTypeName(node) {
     this.registerUsage(node.baseTypeName.namePath)
   }
@@ -47,8 +48,10 @@ class NoUnusedImportsChecker extends BaseChecker {
     this.registerUsage(node.typeName.namePath)
   }
 
-  FunctionCall(node) {
-    this.registerUsage(node.expression.name)
+  Identifier(node) {
+    if (!isImportIdentifier(node)) {
+      this.registerUsage(node.name)
+    }
   }
 
   FunctionDefinition(node) {

--- a/lib/rules/best-practises/no-unused-import.js
+++ b/lib/rules/best-practises/no-unused-import.js
@@ -55,6 +55,9 @@ class NoUnusedImportsChecker extends BaseChecker {
     if (node.override) {
       node.override.forEach((it) => this.registerUsage(it.namePath))
     }
+    if (node.isConstructor) {
+      node.modifiers.forEach((it) => this.registerUsage(it.name))
+    }
   }
 
   ImportDirective(node) {

--- a/lib/rules/best-practises/no-unused-import.js
+++ b/lib/rules/best-practises/no-unused-import.js
@@ -6,8 +6,28 @@ const meta = {
   type: 'best-practises',
 
   docs: {
-    description: 'Imported name is not used',
+    description: 'Reports a warning when an imported name is not used',
     category: 'Best Practise Rules',
+    examples: {
+      good: [
+        {
+          description: 'Imported name is used',
+          code: `
+            import {A} from './A.sol';
+            contract B is A {}
+          `,
+        },
+      ],
+      bad: [
+        {
+          description: 'Imported name is not used',
+          code: `
+            import {A} from './A.sol';
+            contract B {}
+          `,
+        },
+      ],
+    },
   },
 
   isDefault: false,

--- a/lib/rules/best-practises/no-unused-import.js
+++ b/lib/rules/best-practises/no-unused-import.js
@@ -51,6 +51,12 @@ class NoUnusedImportsChecker extends BaseChecker {
     this.registerUsage(node.expression.name)
   }
 
+  FunctionDefinition(node) {
+    if (node.override) {
+      node.override.forEach((it) => this.registerUsage(it.namePath))
+    }
+  }
+
   ImportDirective(node) {
     if (node.unitAlias) {
       this.importedNames[node.unitAlias] = { node: node.unitAliasIdentifier, used: false }

--- a/test/rules/best-practises/no-unused-import.js
+++ b/test/rules/best-practises/no-unused-import.js
@@ -195,6 +195,47 @@ describe('Linter - no-unused-import', () => {
         }
       `,
     },
+    {
+      description: 'Import is used as value in a function parameter',
+      code: `
+        pragma solidity >=0.8.19 <0.9.0;
+
+        import { UD60x18, ZERO } from "@prb/math/UD60x18.sol";
+
+        contract SetProtocolFee_Integration_Fuzz_Test {
+            function testFuzz_SetProtocolFee(UD60x18 newProtocolFee) external {
+                newProtocolFee = _bound(newProtocolFee, 1, MAX_FEE);
+                vm.expectEmit({ emitter: address(comptroller) });
+                emit SetProtocolFee({ admin: users.admin, asset: dai, oldProtocolFee: ZERO, newProtocolFee: newProtocolFee });
+            }
+        }
+      `,
+    },
+    {
+      description: 'Import is used as value in a binary expression',
+      code: `
+        import { ZERO } from "@prb/math/UD60x18.sol";
+
+        contract Foo {
+            function returnFifteen() public returns (uint){
+              return ZERO + 15;
+            }
+        }
+      `,
+    },
+    {
+      description: 'Import is used as value in an assignment',
+      code: `
+        import { ZERO } from "@prb/math/UD60x18.sol";
+
+        contract Foo {
+            uint256 public howMuch;
+            constructor () {
+              howMuch = ZERO;
+            }
+        }
+      `,
+    },
   ].forEach(({ description, code }) => {
     it(`should not raise when ${description}`, () => {
       const report = linter.processStr(code, {

--- a/test/rules/best-practises/no-unused-import.js
+++ b/test/rules/best-practises/no-unused-import.js
@@ -183,6 +183,18 @@ describe('Linter - no-unused-import', () => {
         }
       `,
     },
+    {
+      description: 'Type is used in a constructor initializator',
+      code: `
+        pragma solidity >=0.8.19;
+
+        import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+
+        contract MyContract {
+            constructor() ERC721("Sablier V2 Lockup Dynamic NFT", "SAB-V2-LOCKUP-DYN") { }
+        }
+      `,
+    },
   ].forEach(({ description, code }) => {
     it(`should not raise when ${description}`, () => {
       const report = linter.processStr(code, {

--- a/test/rules/best-practises/no-unused-import.js
+++ b/test/rules/best-practises/no-unused-import.js
@@ -167,6 +167,22 @@ describe('Linter - no-unused-import', () => {
           }
       `,
     },
+    {
+      description: 'Name is used in an override',
+      code: `
+        pragma solidity >=0.8.19;
+
+        import { ERC721 } from "@openzeppelin/contracts/token/ERC721/ERC721.sol";
+        import { IERC721Metadata } from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
+
+        contract MyContract {
+            /// @inheritdoc ERC721
+            function tokenURI(uint256 streamId) public view override(IERC721Metadata, ERC721) returns (string memory uri) {
+                uri = "example.com";
+            }
+        }
+      `,
+    },
   ].forEach(({ description, code }) => {
     it(`should not raise when ${description}`, () => {
       const report = linter.processStr(code, {


### PR DESCRIPTION
should fix:
- [x] #17
- [x] #18
- [x] #19
- [x] #20

before removing the draft status, I should run the updated linter against:
- [x] prb-math -- https://github.com/PaulRBerg/prb-math/pull/196
- [x] prb-proxy -- no issues
- [x] prb-contracts -- https://github.com/PaulRBerg/prb-contracts/pull/43
- [x] sablier-v2 -- no issues

to check for more false positives.

Recommendations on other codebases to check for false positives are of course welcome.

Thanks @paulrberg for reporting this, it really helps to make the linter more robust and to further my
language-fu.
