### PR TITLE
fix false positives on no-unused-imports with inheritdoc

### DIFF
--- a/lib/rules/best-practises/index.js
+++ b/lib/rules/best-practises/index.js
@@ -10,7 +10,7 @@ const NoConsoleLogChecker = require('./no-console')
 const NoGlobalImportsChecker = require('./no-global-import')
 const NoUnusedImportsChecker = require('./no-unused-import')
 
-module.exports = function checkers(reporter, config, inputSrc) {
+module.exports = function checkers(reporter, config, inputSrc, tokens) {
   return [
     new CodeComplexityChecker(reporter, config),
     new FunctionMaxLinesChecker(reporter, config),
@@ -22,6 +22,6 @@ module.exports = function checkers(reporter, config, inputSrc) {
     new ReasonStringChecker(reporter, config),
     new NoConsoleLogChecker(reporter),
     new NoGlobalImportsChecker(reporter),
-    new NoUnusedImportsChecker(reporter),
+    new NoUnusedImportsChecker(reporter, tokens),
   ]
 }

--- a/lib/rules/best-practises/no-unused-import.js
+++ b/lib/rules/best-practises/no-unused-import.js
@@ -43,9 +43,10 @@ function isImportIdentifier(node) {
 }
 
 class NoUnusedImportsChecker extends BaseChecker {
-  constructor(reporter) {
+  constructor(reporter, tokens) {
     super(reporter, ruleId, meta)
     this.importedNames = {}
+    this.tokens = tokens
   }
 
   registerUsage(rawName) {
@@ -117,6 +118,16 @@ class NoUnusedImportsChecker extends BaseChecker {
   }
 
   'SourceUnit:exit'() {
+    const keywords = this.tokens.filter((it) => it.type === 'Keyword')
+    const inheritdocStatements = keywords.filter(
+      ({ value }) => /^\/\/\/ *@inheritdoc/.test(value) || /^\/\*\* *@inheritdoc/.test(value)
+    )
+    inheritdocStatements.forEach(({ value }) => {
+      const match = value.match(/@inheritdoc *([a-zA-Z0-9_]*)/)
+      if (match && match[1]) {
+        this.registerUsage(match[1])
+      }
+    })
     forIn(this.importedNames, (value, key) => {
       if (!value.used) {
         this.error(value.node, `imported name ${key} is not used`)

--- a/lib/rules/index.js
+++ b/lib/rules/index.js
@@ -58,7 +58,7 @@ function coreRules(meta) {
   const { reporter, config, inputSrc, tokens } = meta
 
   return [
-    ...bestPractises(reporter, config, inputSrc),
+    ...bestPractises(reporter, config, inputSrc, tokens),
     ...deprecations(reporter),
     ...miscellaneous(reporter, config, tokens),
     ...naming(reporter, config),


### PR DESCRIPTION
I had to
- plumb the lexed linter input through to the best practices rules
- get the 'keywords' from there, where the comments are
- filter the doxygen directives and parse them manually 😭
- register the import usages when the directive is an @inheritdoc

because
- the grammar defined in the parser sends all comments to a HIDDEN stream, whatever that means (I'm not at all familiar with antlr)
- every comment line is a Keyword on the token stream, but they're no longer available on the AST

This is of course more fragile than it should be, so extra ideas for testcases are welcome.

this begs the question: is natspec available in slang's AST?