### PR TITLE
 deprecate solhint:default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
-## [3.7.0-rc00] - 2023-07-23
+## [3.7.0-rc01] - 2023-07-23
 Current release candidate
+
+### Updated
+- depreacted solhit:default ruleset:
+https://github.com/solhint-community/solhint-community/pull/36
 
 ## [3.6.1] - 2023-07-31
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ First initialize a configuration file, if you don't have one:
 solhint --init
 ```
 
-This will create a `.solhint.json` file with the default rules enabled. Then run Solhint with one or more [Globs](https://en.wikipedia.org/wiki/Glob_(programming)) as arguments. For example, to lint all files inside `contracts` directory, you can do:
+This will create a `.solhint.json` file with the recommended rules enabled. Then run Solhint with one or more [Globs](https://en.wikipedia.org/wiki/Glob_(programming)) as arguments. For example, to lint all files inside `contracts` directory, you can do:
 
 ```sh
 solhint 'contracts/**/*.sol'
@@ -78,7 +78,7 @@ This file has the following format:
 ### Default 
 ```json
 {
-  "extends": "solhint:default"
+  "extends": "solhint:recommended"
 }
 ```
 
@@ -105,9 +105,9 @@ additional-tests.sol
 
 ### Extendable rulesets
 
-The default rulesets provided by solhint are the following:
+The extendable rulesets provided by solhint are the following:
 
-+ solhint:default
++ ~~solhint:default~~ Deprecated as of 3.7.0
 + solhint:recommended
 
 Use one of these as the value for the "extends" property in your configuration file.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -22,7 +22,7 @@ format:
 
 ```json
   {
-    "extends": "solhint:default",
+    "extends": "solhint:recommended",
     "plugins": [],
     "rules": {
       "const-name-snakecase": "off",

--- a/docs/rules/best-practises/max-line-length.md
+++ b/docs/rules/best-practises/max-line-length.md
@@ -7,7 +7,7 @@ title:       "max-line-length | Solhint"
 # max-line-length
 ![Category Badge](https://img.shields.io/badge/-Best%20Practise%20Rules-informational)
 ![Default Severity Badge error](https://img.shields.io/badge/Default%20Severity-error-red)
-> The {"extends": "solhint:default"} property in a configuration file enables this rule.
+> The {"extends": "solhint:default"} property in a configuration file enables this rule. This is currently deprecated and will be removed in version 4.0.0
 
 
 ## Description

--- a/docs/rules/best-practises/no-console.md
+++ b/docs/rules/best-practises/no-console.md
@@ -8,7 +8,7 @@ title:       "no-console | Solhint"
 ![Recommended Badge](https://img.shields.io/badge/-Recommended-brightgreen)
 ![Category Badge](https://img.shields.io/badge/-Best%20Practise%20Rules-informational)
 ![Default Severity Badge error](https://img.shields.io/badge/Default%20Severity-error-red)
-> The {"extends": "solhint:default"} property in a configuration file enables this rule.
+> The {"extends": "solhint:default"} property in a configuration file enables this rule. This is currently deprecated and will be removed in version 4.0.0
 
 > The {"extends": "solhint:recommended"} property in a configuration file enables this rule.
 

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -29,6 +29,17 @@ function useFixture(dir) {
 describe('e2e', function () {
   describe('no config', function () {
     useFixture('01-no-config')
+    describe('GIVEN a config file created with solhint --init', function () {
+      beforeEach(function () {
+        shell.exec('solhint --init')
+      })
+
+      it('WHEN linting a file, THEN the config is used ', function () {
+        const { code, stdout } = shell.exec('solhint Foo.sol')
+        expect(code).to.equal(1)
+        expect(stdout.trim()).to.contain('Code contains empty blocks')
+      })
+    })
 
     it('should fail', function () {
       const { code } = shell.exec('solhint Foo.sol')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solhint-community",
-  "version": "3.7.0-rc00",
+  "version": "3.7.0-rc01",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solhint-community",
-      "version": "3.7.0-rc00",
+      "version": "3.7.0-rc01",
       "license": "MIT",
       "dependencies": {
         "@solidity-parser/parser": "^0.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "solhint-community",
-  "version": "3.7.0-rc00",
+  "version": "3.7.0-rc01",
   "description": "Solidity Code Linter",
   "main": "lib/index.js",
   "keywords": [

--- a/scripts/generate-rule-docs.js
+++ b/scripts/generate-rule-docs.js
@@ -84,7 +84,7 @@ ${[
   categoryBadge(rule.meta.docs.category),
   defaultSeverityBadge(defaultSeverity),
   isDefault
-    ? '> The {"extends": "solhint:default"} property in a configuration file enables this rule.\n'
+    ? '> The {"extends": "solhint:default"} property in a configuration file enables this rule. This is currently deprecated and will be removed in version 4.0.0\n'
     : '',
   isRecommended
     ? '> The {"extends": "solhint:recommended"} property in a configuration file enables this rule.\n'

--- a/solhint.js
+++ b/solhint.js
@@ -126,7 +126,7 @@ function processStdin(options) {
 function writeSampleConfigFile() {
   const configPath = '.solhint.json'
   const sampleConfig = `{
-  "extends": "solhint:default"
+  "extends": "solhint:recommended"
 }
 `
 


### PR DESCRIPTION
only max-line-length and no-console are default rules. This group does not make any semantic sense and is very small. And considering there were [issues](https://github.com/protofire/solhint/issues/429) in legacy solhint by users being confused by it not reporting any errors, I hereby propose we get rid of the solhint:default ruleset. 

This PR marks it as deprecated in the docs and, crucially, makes `solhint --init` create a config extending `solhint:recommended`
