### PR TITLE
Backport explicit-types

### DIFF
--- a/docs/rules.md
+++ b/docs/rules.md
@@ -10,7 +10,7 @@ title:       "Rule Index of Solhint"
 | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ----------- |
 | [code-complexity](./rules/best-practises/code-complexity.md)             | Function has cyclomatic complexity "current" but allowed no more than maxcompl.                                       |             |
 | [custom-errors](./rules/best-practises/custom-errors.md)                 | Enforces the use of Custom Errors over Require and Revert statements                                                  |             |
-| [explicit-types](./rules/best-practises/explicit-types.md)               | Forbid or enforce explicit types (like uint256) that have an alias (like uint).                                       | ✔️          |
+| [explicit-types](./rules/best-practises/explicit-types.md)               | Enforce explicit types (like uint256) over implicit ones(like uint).                                                  |             |
 | [function-max-lines](./rules/best-practises/function-max-lines.md)       | Function body contains "count" lines but allowed no more than maxlines.                                               |             |
 | [max-line-length](./rules/best-practises/max-line-length.md)             | Line length must be no more than maxlen.                                                                              |             |
 | [max-states-count](./rules/best-practises/max-states-count.md)           | Contract has "some count" states declarations but allowed no more than maxstates.                                     | ✔️          |

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -10,6 +10,7 @@ title:       "Rule Index of Solhint"
 | ------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------- | ----------- |
 | [code-complexity](./rules/best-practises/code-complexity.md)             | Function has cyclomatic complexity "current" but allowed no more than maxcompl.                                       |             |
 | [custom-errors](./rules/best-practises/custom-errors.md)                 | Enforces the use of Custom Errors over Require and Revert statements                                                  |             |
+| [explicit-types](./rules/best-practises/explicit-types.md)               | Forbid or enforce explicit types (like uint256) that have an alias (like uint).                                       | ✔️          |
 | [function-max-lines](./rules/best-practises/function-max-lines.md)       | Function body contains "count" lines but allowed no more than maxlines.                                               |             |
 | [max-line-length](./rules/best-practises/max-line-length.md)             | Line length must be no more than maxlen.                                                                              |             |
 | [max-states-count](./rules/best-practises/max-states-count.md)           | Contract has "some count" states declarations but allowed no more than maxstates.                                     | ✔️          |

--- a/docs/rules/best-practises/explicit-types.md
+++ b/docs/rules/best-practises/explicit-types.md
@@ -5,14 +5,11 @@ title:       "explicit-types | Solhint"
 ---
 
 # explicit-types
-![Recommended Badge](https://img.shields.io/badge/-Recommended-brightgreen)
 ![Category Badge](https://img.shields.io/badge/-Best%20Practise%20Rules-informational)
 ![Default Severity Badge warn](https://img.shields.io/badge/Default%20Severity-warn-yellow)
-> The {"extends": "solhint:recommended"} property in a configuration file enables this rule.
-
 
 ## Description
-Forbid or enforce explicit types (like uint256) that have an alias (like uint).
+Enforce explicit types (like uint256) over implicit ones(like uint).
 
 ## Options
 This rule accepts an array of options:
@@ -20,14 +17,13 @@ This rule accepts an array of options:
 | Index | Description                                           | Default Value |
 | ----- | ----------------------------------------------------- | ------------- |
 | 0     | Rule severity. Must be one of "error", "warn", "off". | warn          |
-| 1     | Options need to be one of "explicit", "implicit"      | explicit      |
 
 
 ### Example Config
 ```json
 {
   "rules": {
-    "explicit-types": ["warn","explicit"]
+    "explicit-types": ["warn"]
   }
 }
 ```
@@ -36,19 +32,19 @@ This rule accepts an array of options:
 ## Examples
 ### 👍 Examples of **correct** code for this rule
 
-#### If explicit is selected
+#### using a type that explicitly states the variable size
 
 ```solidity
 uint256 public variableName
 ```
 
-#### If implicit is selected
+#### using a type that explicitly states the variable size
 
 ```solidity
-uint public variableName
+fixed128x18 public foo
 ```
 
-#### If explicit is selected
+#### using a type that explicitly states the variable size
 
 ```solidity
 uint256 public variableName = uint256(5)
@@ -56,22 +52,22 @@ uint256 public variableName = uint256(5)
 
 ### 👎 Examples of **incorrect** code for this rule
 
-#### If explicit is selected
+#### using the shorter alias for a type, which is implicit about its size
 
 ```solidity
 uint public variableName
 ```
 
-#### If implicit is selected
+#### using the shorter alias for a type, which is implicit about its size
 
 ```solidity
-uint256 public variableName
+fixed public foo
 ```
 
-#### At any setting
+#### using the shorter alias for a type, which is implicit about its size
 
 ```solidity
-uint public variableName = uint256(5)
+uint public variableName = uint(5)
 ```
 
 ## Version

--- a/docs/rules/best-practises/explicit-types.md
+++ b/docs/rules/best-practises/explicit-types.md
@@ -1,0 +1,83 @@
+---
+warning:     "This is a dynamically generated file. Do not edit manually."
+layout:      "default"
+title:       "explicit-types | Solhint"
+---
+
+# explicit-types
+![Recommended Badge](https://img.shields.io/badge/-Recommended-brightgreen)
+![Category Badge](https://img.shields.io/badge/-Best%20Practise%20Rules-informational)
+![Default Severity Badge warn](https://img.shields.io/badge/Default%20Severity-warn-yellow)
+> The {"extends": "solhint:recommended"} property in a configuration file enables this rule.
+
+
+## Description
+Forbid or enforce explicit types (like uint256) that have an alias (like uint).
+
+## Options
+This rule accepts an array of options:
+
+| Index | Description                                           | Default Value |
+| ----- | ----------------------------------------------------- | ------------- |
+| 0     | Rule severity. Must be one of "error", "warn", "off". | warn          |
+| 1     | Options need to be one of "explicit", "implicit"      | explicit      |
+
+
+### Example Config
+```json
+{
+  "rules": {
+    "explicit-types": ["warn","explicit"]
+  }
+}
+```
+
+
+## Examples
+### 👍 Examples of **correct** code for this rule
+
+#### If explicit is selected
+
+```solidity
+uint256 public variableName
+```
+
+#### If implicit is selected
+
+```solidity
+uint public variableName
+```
+
+#### If explicit is selected
+
+```solidity
+uint256 public variableName = uint256(5)
+```
+
+### 👎 Examples of **incorrect** code for this rule
+
+#### If explicit is selected
+
+```solidity
+uint public variableName
+```
+
+#### If implicit is selected
+
+```solidity
+uint256 public variableName
+```
+
+#### At any setting
+
+```solidity
+uint public variableName = uint256(5)
+```
+
+## Version
+This rule is introduced in the latest version.
+
+## Resources
+- [Rule source](https://github.com/solhint-community/solhint-community/tree/master/lib/rules/best-practises/explicit-types.js)
+- [Document source](https://github.com/solhint-community/solhint-community/tree/master/docs/rules/best-practises/explicit-types.md)
+- [Test cases](https://github.com/solhint-community/solhint-community/tree/master/test/rules/best-practises/explicit-types.js)

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,6 +20,15 @@ module.exports = {
     return _.isString(configVal) ? configVal : defaultValue
   },
 
+  getStringFromArray(ruleName, defaultValue) {
+    if (this.rules && this.rules[ruleName]) {
+      const ruleValue = this.rules[ruleName]
+      return Array.isArray(ruleValue) ? ruleValue[1] : defaultValue
+    } else {
+      return defaultValue
+    }
+  },
+
   getNumber(ruleName, defaultValue) {
     return this.getNumberByPath(`rules["${ruleName}"][1]`, defaultValue)
   },

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,15 +20,6 @@ module.exports = {
     return _.isString(configVal) ? configVal : defaultValue
   },
 
-  getStringFromArray(ruleName, defaultValue) {
-    if (this.rules && this.rules[ruleName]) {
-      const ruleValue = this.rules[ruleName]
-      return Array.isArray(ruleValue) ? ruleValue[1] : defaultValue
-    } else {
-      return defaultValue
-    }
-  },
-
   getNumber(ruleName, defaultValue) {
     return this.getNumberByPath(`rules["${ruleName}"][1]`, defaultValue)
   },

--- a/lib/rules/best-practises/explicit-types.js
+++ b/lib/rules/best-practises/explicit-types.js
@@ -1,7 +1,12 @@
 const BaseChecker = require('../base-checker')
 const { severityDescription } = require('../../doc/utils')
 
-const IMPLICIT_TYPES = ['uint', 'int', 'ufixed', 'fixed']
+const IMPLICIT_TO_EXPLICIT = {
+  uint: 'uint256',
+  int: 'int256',
+  ufixed: 'ufixed128x18',
+  fixed: 'fixed128x18',
+}
 const DEFAULT_SEVERITY = 'warn'
 
 const ruleId = 'explicit-types'
@@ -91,9 +96,12 @@ class ExplicitTypesChecker extends BaseChecker {
   }
 
   validateTypeName(node, typeName) {
-    if (IMPLICIT_TYPES.includes(typeName.name)) {
+    if (Object.keys(IMPLICIT_TO_EXPLICIT).includes(typeName.name)) {
       if (!this.reported.has(node)) {
-        this.error(node, 'prefer use of explicit type')
+        this.error(
+          node,
+          `prefer use of explicit type ${IMPLICIT_TO_EXPLICIT[typeName.name]} over ${typeName.name}`
+        )
         this.reported.add(node)
       }
     }

--- a/lib/rules/best-practises/explicit-types.js
+++ b/lib/rules/best-practises/explicit-types.js
@@ -1,11 +1,7 @@
 const BaseChecker = require('../base-checker')
-const { severityDescription, formatEnum } = require('../../doc/utils')
+const { severityDescription } = require('../../doc/utils')
 
-const EXPLICIT_TYPES = ['uint256', 'int256', 'ufixed128x18', 'fixed128x18']
 const IMPLICIT_TYPES = ['uint', 'int', 'ufixed', 'fixed']
-const ALL_TYPES = EXPLICIT_TYPES.concat(IMPLICIT_TYPES)
-const VALID_CONFIGURATION_OPTIONS = ['explicit', 'implicit']
-const DEFAULT_OPTION = 'explicit'
 const DEFAULT_SEVERITY = 'warn'
 
 const ruleId = 'explicit-types'
@@ -13,45 +9,41 @@ const meta = {
   type: 'best-practises',
 
   docs: {
-    description: 'Forbid or enforce explicit types (like uint256) that have an alias (like uint).',
+    description: 'Enforce explicit types (like uint256) over implicit ones(like uint).',
     category: 'Best Practise Rules',
     options: [
       {
         description: severityDescription,
         default: DEFAULT_SEVERITY,
       },
-      {
-        description: `Options need to be one of ${formatEnum(VALID_CONFIGURATION_OPTIONS)}`,
-        default: DEFAULT_OPTION,
-      },
     ],
     examples: {
       good: [
         {
-          description: 'If explicit is selected',
+          description: 'using a type that explicitly states the variable size',
           code: 'uint256 public variableName',
         },
         {
-          description: 'If implicit is selected',
-          code: 'uint public variableName',
+          description: 'using a type that explicitly states the variable size',
+          code: 'fixed128x18 public foo',
         },
         {
-          description: 'If explicit is selected',
+          description: 'using a type that explicitly states the variable size',
           code: 'uint256 public variableName = uint256(5)',
         },
       ],
       bad: [
         {
-          description: 'If explicit is selected',
+          description: 'using the shorter alias for a type, which is implicit about its size',
           code: 'uint public variableName',
         },
         {
-          description: 'If implicit is selected',
-          code: 'uint256 public variableName',
+          description: 'using the shorter alias for a type, which is implicit about its size',
+          code: 'fixed public foo',
         },
         {
-          description: 'At any setting',
-          code: 'uint public variableName = uint256(5)',
+          description: 'using the shorter alias for a type, which is implicit about its size',
+          code: 'uint public variableName = uint(5)',
         },
       ],
     },
@@ -59,88 +51,52 @@ const meta = {
 
   isDefault: false,
   recommended: false,
-  defaultSetup: [DEFAULT_SEVERITY, DEFAULT_OPTION],
+  defaultSetup: [DEFAULT_SEVERITY],
 
-  schema: {
-    type: 'string',
-    enum: VALID_CONFIGURATION_OPTIONS,
-  },
+  schema: {},
 }
 
 class ExplicitTypesChecker extends BaseChecker {
-  constructor(reporter, config) {
+  constructor(reporter) {
     super(reporter, ruleId, meta)
-    this.configOption =
-      (config && config.getStringFromArray(ruleId, DEFAULT_OPTION)) || DEFAULT_OPTION
-    this.isExplicit = this.configOption === 'explicit'
+    // TODO: I had to add the set because the FunctionCall callback was being
+    // called multiple times for the same cast, it's possible that its a bug
+    // with the AST visitor. Do a PoC and ask for help
+    this.reported = new Set()
   }
 
   VariableDeclaration(node) {
-    this.validateInNode(node)
+    this.validateTypeName(node, node.typeName)
   }
 
-  VariableDeclarationStatement(node) {
-    if (!node.initialValue) return
-    this.validateInNode(node.initialValue)
-  }
-
-  ExpressionStatement(node) {
-    this.validateInNode(node)
-  }
-
-  validateInNode(node) {
-    if (!VALID_CONFIGURATION_OPTIONS.includes(this.configOption)) {
-      this.error(node, 'Error: Config error on [explicit-types]. See explicit-types.md.')
-      return
-    }
-
-    const typeToFind = 'ElementaryTypeName'
-    const onlyTypes = this.findNamesOfElementaryTypeName(node, typeToFind)
-
-    // if no variables are defined, return
-    if (onlyTypes && onlyTypes.length === 0) return
-
-    // this tells if the variable needs to be checked
-    const varsToBeChecked = onlyTypes.filter((type) => ALL_TYPES.includes(type))
-
-    // if defined variables are not to be checked (example address type), return
-    if (varsToBeChecked && varsToBeChecked.length === 0) return
-
-    // if explicit, it will search for implicit and viceversa
-    if (this.isExplicit) {
-      this.validateVariables(IMPLICIT_TYPES, node, varsToBeChecked)
-    } else {
-      this.validateVariables(EXPLICIT_TYPES, node, varsToBeChecked)
+  FunctionCall(node) {
+    if (node.expression.type === 'ElementaryTypeName') {
+      this.validateTypeName(node, node.expression)
     }
   }
 
-  validateVariables(configType, node, varsToBeChecked) {
-    const errorVars = varsToBeChecked.filter((type) => configType.includes(type))
+  ArrayTypeName(node) {
+    if (node.baseTypeName.type === 'ElementaryTypeName') {
+      this.validateTypeName(node, node.baseTypeName)
+    }
+  }
 
-    if (errorVars && errorVars.length > 0) {
-      for (const errorVar of errorVars) {
-        this.error(node, `Rule is set with ${this.configOption} type [var/s: ${errorVar}]`)
+  Mapping(node) {
+    if (node.keyType.type === 'ElementaryTypeName') {
+      this.validateTypeName(node, node.keyType)
+    }
+    if (node.valueType.type === 'ElementaryTypeName') {
+      this.validateTypeName(node, node.valueType)
+    }
+  }
+
+  validateTypeName(node, typeName) {
+    if (IMPLICIT_TYPES.includes(typeName.name)) {
+      if (!this.reported.has(node)) {
+        this.error(node, 'prefer use of explicit type')
+        this.reported.add(node)
       }
     }
-  }
-
-  findNamesOfElementaryTypeName(jsonObject, typeToFind) {
-    const names = []
-
-    const searchInObject = (obj) => {
-      if (obj.type === typeToFind && obj.name) {
-        names.push(obj.name)
-      }
-
-      for (const key in obj) {
-        if (typeof obj[key] === 'object' && obj[key] !== null) {
-          searchInObject(obj[key])
-        }
-      }
-    }
-
-    searchInObject(jsonObject)
-    return names
   }
 }
 

--- a/lib/rules/best-practises/explicit-types.js
+++ b/lib/rules/best-practises/explicit-types.js
@@ -1,0 +1,147 @@
+const BaseChecker = require('../base-checker')
+const { severityDescription, formatEnum } = require('../../doc/utils')
+
+const EXPLICIT_TYPES = ['uint256', 'int256', 'ufixed128x18', 'fixed128x18']
+const IMPLICIT_TYPES = ['uint', 'int', 'ufixed', 'fixed']
+const ALL_TYPES = EXPLICIT_TYPES.concat(IMPLICIT_TYPES)
+const VALID_CONFIGURATION_OPTIONS = ['explicit', 'implicit']
+const DEFAULT_OPTION = 'explicit'
+const DEFAULT_SEVERITY = 'warn'
+
+const ruleId = 'explicit-types'
+const meta = {
+  type: 'best-practises',
+
+  docs: {
+    description: 'Forbid or enforce explicit types (like uint256) that have an alias (like uint).',
+    category: 'Best Practise Rules',
+    options: [
+      {
+        description: severityDescription,
+        default: DEFAULT_SEVERITY,
+      },
+      {
+        description: `Options need to be one of ${formatEnum(VALID_CONFIGURATION_OPTIONS)}`,
+        default: DEFAULT_OPTION,
+      },
+    ],
+    examples: {
+      good: [
+        {
+          description: 'If explicit is selected',
+          code: 'uint256 public variableName',
+        },
+        {
+          description: 'If implicit is selected',
+          code: 'uint public variableName',
+        },
+        {
+          description: 'If explicit is selected',
+          code: 'uint256 public variableName = uint256(5)',
+        },
+      ],
+      bad: [
+        {
+          description: 'If explicit is selected',
+          code: 'uint public variableName',
+        },
+        {
+          description: 'If implicit is selected',
+          code: 'uint256 public variableName',
+        },
+        {
+          description: 'At any setting',
+          code: 'uint public variableName = uint256(5)',
+        },
+      ],
+    },
+  },
+
+  isDefault: false,
+  recommended: true,
+  defaultSetup: [DEFAULT_SEVERITY, DEFAULT_OPTION],
+
+  schema: {
+    type: 'string',
+    enum: VALID_CONFIGURATION_OPTIONS,
+  },
+}
+
+class ExplicitTypesChecker extends BaseChecker {
+  constructor(reporter, config) {
+    super(reporter, ruleId, meta)
+    this.configOption =
+      (config && config.getStringFromArray(ruleId, DEFAULT_OPTION)) || DEFAULT_OPTION
+    this.isExplicit = this.configOption === 'explicit'
+  }
+
+  VariableDeclaration(node) {
+    this.validateInNode(node)
+  }
+
+  VariableDeclarationStatement(node) {
+    if (!node.initialValue) return
+    this.validateInNode(node.initialValue)
+  }
+
+  ExpressionStatement(node) {
+    this.validateInNode(node)
+  }
+
+  validateInNode(node) {
+    if (!VALID_CONFIGURATION_OPTIONS.includes(this.configOption)) {
+      this.error(node, 'Error: Config error on [explicit-types]. See explicit-types.md.')
+      return
+    }
+
+    const typeToFind = 'ElementaryTypeName'
+    const onlyTypes = this.findNamesOfElementaryTypeName(node, typeToFind)
+
+    // if no variables are defined, return
+    if (onlyTypes && onlyTypes.length === 0) return
+
+    // this tells if the variable needs to be checked
+    const varsToBeChecked = onlyTypes.filter((type) => ALL_TYPES.includes(type))
+
+    // if defined variables are not to be checked (example address type), return
+    if (varsToBeChecked && varsToBeChecked.length === 0) return
+
+    // if explicit, it will search for implicit and viceversa
+    if (this.isExplicit) {
+      this.validateVariables(IMPLICIT_TYPES, node, varsToBeChecked)
+    } else {
+      this.validateVariables(EXPLICIT_TYPES, node, varsToBeChecked)
+    }
+  }
+
+  validateVariables(configType, node, varsToBeChecked) {
+    const errorVars = varsToBeChecked.filter((type) => configType.includes(type))
+
+    if (errorVars && errorVars.length > 0) {
+      for (const errorVar of errorVars) {
+        this.error(node, `Rule is set with ${this.configOption} type [var/s: ${errorVar}]`)
+      }
+    }
+  }
+
+  findNamesOfElementaryTypeName(jsonObject, typeToFind) {
+    const names = []
+
+    const searchInObject = (obj) => {
+      if (obj.type === typeToFind && obj.name) {
+        names.push(obj.name)
+      }
+
+      for (const key in obj) {
+        if (typeof obj[key] === 'object' && obj[key] !== null) {
+          searchInObject(obj[key])
+        }
+      }
+    }
+
+    searchInObject(jsonObject)
+    return names
+  }
+}
+
+module.exports = ExplicitTypesChecker

--- a/lib/rules/best-practises/explicit-types.js
+++ b/lib/rules/best-practises/explicit-types.js
@@ -58,7 +58,7 @@ const meta = {
   },
 
   isDefault: false,
-  recommended: true,
+  recommended: false,
   defaultSetup: [DEFAULT_SEVERITY, DEFAULT_OPTION],
 
   schema: {

--- a/lib/rules/best-practises/index.js
+++ b/lib/rules/best-practises/index.js
@@ -26,6 +26,6 @@ module.exports = function checkers(reporter, config, inputSrc, tokens) {
     new NoGlobalImportsChecker(reporter),
     new NoUnusedImportsChecker(reporter, tokens),
     new CustomErrorsChecker(reporter),
-    new ExplicitTypesChecker(reporter, config),
+    new ExplicitTypesChecker(reporter),
   ]
 }

--- a/lib/rules/best-practises/index.js
+++ b/lib/rules/best-practises/index.js
@@ -10,6 +10,7 @@ const NoConsoleLogChecker = require('./no-console')
 const NoGlobalImportsChecker = require('./no-global-import')
 const NoUnusedImportsChecker = require('./no-unused-import')
 const CustomErrorsChecker = require('./custom-errors')
+const ExplicitTypesChecker = require('./explicit-types')
 
 module.exports = function checkers(reporter, config, inputSrc, tokens) {
   return [
@@ -25,5 +26,6 @@ module.exports = function checkers(reporter, config, inputSrc, tokens) {
     new NoGlobalImportsChecker(reporter),
     new NoUnusedImportsChecker(reporter, tokens),
     new CustomErrorsChecker(reporter),
+    new ExplicitTypesChecker(reporter, config),
   ]
 }

--- a/test/fixtures/best-practises/explicit-types.js
+++ b/test/fixtures/best-practises/explicit-types.js
@@ -1,0 +1,177 @@
+const VAR_DECLARATIONS = {
+  uint256: {
+    code: 'uint256 public varUint256;',
+    errorsImplicit: 1,
+    errorsExplicit: 0,
+  },
+
+  uint: {
+    code: 'uint public varUint;',
+    errorsImplicit: 0,
+    errorsExplicit: 1,
+  },
+
+  int256: {
+    code: 'int256 public varInt256;',
+    errorsImplicit: 1,
+    errorsExplicit: 0,
+  },
+
+  int: {
+    code: 'int public varInt;',
+    errorsImplicit: 0,
+    errorsExplicit: 1,
+  },
+
+  ufixed128x18: {
+    code: 'ufixed128x18 public varUfixed128x18;',
+    errorsImplicit: 1,
+    errorsExplicit: 0,
+  },
+
+  ufixed: {
+    code: 'ufixed public varUfixed;',
+    errorsImplicit: 0,
+    errorsExplicit: 1,
+  },
+
+  fixed128x18: {
+    code: 'fixed128x18 public varFixed128x18;',
+    errorsImplicit: 1,
+    errorsExplicit: 0,
+  },
+
+  fixed: {
+    code: 'fixed public varFixed;',
+    errorsImplicit: 0,
+    errorsExplicit: 1,
+  },
+
+  functionParameterAndReturns1: {
+    code: 'function withUint256(uint256 varUint256, uint varUint) public returns(int256 returnInt256) {}',
+    errorsImplicit: 2,
+    errorsExplicit: 1,
+  },
+
+  functionParameterAndReturns2: {
+    code: 'function withUint256(uint varUint, uint varUint) public returns(int returnInt) {}',
+    errorsImplicit: 0,
+    errorsExplicit: 3,
+  },
+
+  eventParameter: {
+    code: 'event EventWithInt256(int256 varWithInt256, address addressVar, bool boolVat, int varWithInt);',
+    errorsImplicit: 1,
+    errorsExplicit: 1,
+  },
+
+  regularMap1: {
+    code: 'mapping(uint256 => fixed128x18) public mapWithFixed128x18;',
+    errorsImplicit: 2,
+    errorsExplicit: 0,
+  },
+
+  regularMap2: {
+    code: 'mapping(uint => fixed128x18) public mapWithFixed128x18;',
+    errorsImplicit: 1,
+    errorsExplicit: 1,
+  },
+
+  mapOfMapping: {
+    code: 'mapping(uint => mapping(fixed128x18 => int256)) mapOfMap;',
+    errorsImplicit: 2,
+    errorsExplicit: 1,
+  },
+
+  struct: {
+    code: 'struct Estructura { ufixed128x18 varWithUfixed128x18; uint varUint; }',
+    errorsImplicit: 1,
+    errorsExplicit: 1,
+  },
+
+  mapOfStruct: {
+    code: 'struct Estructura { ufixed128x18 varWithUfixed128x18; uint varUint; mapping(uint256 => Estructura) mapOfStruct; }',
+    errorsImplicit: 2,
+    errorsExplicit: 1,
+  },
+
+  structWithMap: {
+    code: 'struct Estructura { ufixed varWithUfixed; uint varUint; mapping(address => uint256) structWithMap; } ',
+    errorsImplicit: 1,
+    errorsExplicit: 2,
+  },
+
+  mapOfArrayStructWithMap: {
+    code: 'struct Estructura { ufixed varWithUfixed; uint varUint; mapping(address => uint256) structWithMap; } mapping(uint256 => Estructura[]) mapOfArrayStructWithMap;',
+    errorsImplicit: 2,
+    errorsExplicit: 2,
+  },
+
+  regularArray: {
+    code: 'uint256[] public arr;',
+    errorsImplicit: 1,
+    errorsExplicit: 0,
+  },
+
+  fixedArray: {
+    code: 'uint[] public arr = [1,2,3];',
+    errorsImplicit: 0,
+    errorsExplicit: 1,
+  },
+
+  fixedArrayCastInDeclaration: {
+    code: 'uint[] public arr = [uint(1),2,3];',
+    errorsImplicit: 0,
+    errorsExplicit: 2,
+  },
+
+  fixedArrayOfArrays: {
+    code: 'uint256[] public arr = [[1,2,3]];',
+    errorsImplicit: 1,
+    errorsExplicit: 0,
+  },
+
+  mapOfFixedArray: {
+    code: 'uint[] public arr = [1,2,3]; mapping(uint256 => arr) mapOfFixedArray;',
+    errorsImplicit: 1,
+    errorsExplicit: 1,
+  },
+
+  castInStateVariableDeclaration: {
+    code: 'uint256 public varUint256 = uint256(1); uint public varUint = uint(1);',
+    errorsImplicit: 2,
+    errorsExplicit: 2,
+  },
+
+  castInsideFunctionAtDeclarationUint256: {
+    code: 'function withUint256() external { uint256 varUint256 = uint256(1); }',
+    errorsImplicit: 2,
+    errorsExplicit: 0,
+  },
+
+  castInsideFunctionAtDeclarationUint: {
+    code: 'function withUint() external { uint varUint = uint(1); }',
+    errorsImplicit: 0,
+    errorsExplicit: 2,
+  },
+
+  castInsideFunctionUint: {
+    code: 'function withUint() external { uint varUint; varUint = uint(1);}',
+    errorsImplicit: 0,
+    errorsExplicit: 2,
+  },
+
+  castInsideFunctionUint256: {
+    code: 'function withUint256() external { uint256 varUint; varUint = uint256(1);}',
+    errorsImplicit: 2,
+    errorsExplicit: 0,
+  },
+
+  castInsideModifier: {
+    code: 'modifier withUint256() { _; uint256 varUint; varUint = uint256(1);}',
+    errorsImplicit: 2,
+    errorsExplicit: 0,
+  },
+}
+
+module.exports = VAR_DECLARATIONS

--- a/test/fixtures/best-practises/explicit-types.js
+++ b/test/fixtures/best-practises/explicit-types.js
@@ -4,18 +4,26 @@ const VAR_DECLARATIONS = {
   uint256: {
     explicit: 'uint256 public varUint256;',
     implicit: 'uint public varUint;',
+    implicitTypeName: 'uint',
+    explicitTypeName: 'uint256',
   },
   int256: {
     explicit: 'int256 public varInt256;',
     implicit: 'int public varInt;',
+    implicitTypeName: 'int',
+    explicitTypeName: 'int256',
   },
   ufixed128x18: {
     explicit: 'ufixed128x18 public varUfixed128x18;',
     implicit: 'ufixed public varUfixed;',
+    implicitTypeName: 'ufixed',
+    explicitTypeName: 'ufixed128x18',
   },
   fixed128x18: {
     explicit: 'fixed128x18 public varFixed128x18;',
     implicit: 'fixed public varFixed;',
+    implicitTypeName: 'fixed',
+    explicitTypeName: 'fixed128x18',
   },
 
   // Here I try to be sure I don't miss places where a type can be used

--- a/test/fixtures/best-practises/explicit-types.js
+++ b/test/fixtures/best-practises/explicit-types.js
@@ -1,176 +1,79 @@
 const VAR_DECLARATIONS = {
+  // these cases try to make sure I catch every *type* that can be made explicit
+  // or implicit
   uint256: {
-    code: 'uint256 public varUint256;',
-    errorsImplicit: 1,
-    errorsExplicit: 0,
+    explicit: 'uint256 public varUint256;',
+    implicit: 'uint public varUint;',
   },
-
-  uint: {
-    code: 'uint public varUint;',
-    errorsImplicit: 0,
-    errorsExplicit: 1,
-  },
-
   int256: {
-    code: 'int256 public varInt256;',
-    errorsImplicit: 1,
-    errorsExplicit: 0,
+    explicit: 'int256 public varInt256;',
+    implicit: 'int public varInt;',
   },
-
-  int: {
-    code: 'int public varInt;',
-    errorsImplicit: 0,
-    errorsExplicit: 1,
-  },
-
   ufixed128x18: {
-    code: 'ufixed128x18 public varUfixed128x18;',
-    errorsImplicit: 1,
-    errorsExplicit: 0,
+    explicit: 'ufixed128x18 public varUfixed128x18;',
+    implicit: 'ufixed public varUfixed;',
   },
-
-  ufixed: {
-    code: 'ufixed public varUfixed;',
-    errorsImplicit: 0,
-    errorsExplicit: 1,
-  },
-
   fixed128x18: {
-    code: 'fixed128x18 public varFixed128x18;',
-    errorsImplicit: 1,
-    errorsExplicit: 0,
+    explicit: 'fixed128x18 public varFixed128x18;',
+    implicit: 'fixed public varFixed;',
   },
 
-  fixed: {
-    code: 'fixed public varFixed;',
-    errorsImplicit: 0,
-    errorsExplicit: 1,
+  // Here I try to be sure I don't miss places where a type can be used
+  functionParameterUint256: {
+    explicit: 'function withUint256(uint256 varUint256) public {}',
+    implicit: 'function withUint256(uint varUint256) public {}',
   },
-
-  functionParameterAndReturns1: {
-    code: 'function withUint256(uint256 varUint256, uint varUint) public returns(int256 returnInt256) {}',
-    errorsImplicit: 2,
-    errorsExplicit: 1,
+  functionReturn: {
+    explicit: 'function foo() public returns(int256 returnInt) {}',
+    implicit: 'function foo() public returns(int returnInt) {}',
   },
-
-  functionParameterAndReturns2: {
-    code: 'function withUint256(uint varUint, uint varUint) public returns(int returnInt) {}',
-    errorsImplicit: 0,
-    errorsExplicit: 3,
-  },
-
   eventParameter: {
-    code: 'event EventWithInt256(int256 varWithInt256, address addressVar, bool boolVat, int varWithInt);',
-    errorsImplicit: 1,
-    errorsExplicit: 1,
+    implicit: 'event EventWithInt256(int varWithInt256);',
+    explicit: 'event EventWithInt256(int256 varWithInt256);',
   },
-
-  regularMap1: {
-    code: 'mapping(uint256 => fixed128x18) public mapWithFixed128x18;',
-    errorsImplicit: 2,
-    errorsExplicit: 0,
+  mappingKey: {
+    implicit: 'mapping(uint => fixed128x18) public map;',
+    explicit: 'mapping(uint256 => fixed128x18) public map;',
   },
-
-  regularMap2: {
-    code: 'mapping(uint => fixed128x18) public mapWithFixed128x18;',
-    errorsImplicit: 1,
-    errorsExplicit: 1,
+  mappingValue: {
+    implicit: 'mapping(uint256 => fixed) public map;',
+    explicit: 'mapping(uint256 => fixed128x18) public map;',
   },
-
-  mapOfMapping: {
-    code: 'mapping(uint => mapping(fixed128x18 => int256)) mapOfMap;',
-    errorsImplicit: 2,
-    errorsExplicit: 1,
+  nestedMappingKey: {
+    implicit: 'mapping(uint256 => mapping(fixed => int256)) mapOfMap;',
+    explicit: 'mapping(uint256 => mapping(fixed128x18 => int256)) mapOfMap;',
   },
-
-  struct: {
-    code: 'struct Estructura { ufixed128x18 varWithUfixed128x18; uint varUint; }',
-    errorsImplicit: 1,
-    errorsExplicit: 1,
+  nestedMappingValue: {
+    implicit: 'mapping(uint256 => mapping(fixed128x18 => int)) mapOfMap;',
+    explicit: 'mapping(uint256 => mapping(fixed128x18 => int256)) mapOfMap;',
   },
-
-  mapOfStruct: {
-    code: 'struct Estructura { ufixed128x18 varWithUfixed128x18; uint varUint; mapping(uint256 => Estructura) mapOfStruct; }',
-    errorsImplicit: 2,
-    errorsExplicit: 1,
+  structMember: {
+    implicit: 'struct Estructura { uint varUint; }',
+    explicit: 'struct Estructura { uint256 varUint; }',
   },
-
-  structWithMap: {
-    code: 'struct Estructura { ufixed varWithUfixed; uint varUint; mapping(address => uint256) structWithMap; } ',
-    errorsImplicit: 1,
-    errorsExplicit: 2,
+  structWithMappingMember: {
+    implicit: 'struct Estructura { mapping(address => uint) structWithMap; } ',
+    explicit: 'struct Estructura { mapping(address => uint256) structWithMap; } ',
   },
-
-  mapOfArrayStructWithMap: {
-    code: 'struct Estructura { ufixed varWithUfixed; uint varUint; mapping(address => uint256) structWithMap; } mapping(uint256 => Estructura[]) mapOfArrayStructWithMap;',
-    errorsImplicit: 2,
-    errorsExplicit: 2,
+  array: {
+    implicit: 'uint[] public arr;',
+    explicit: 'uint256[] public arr;',
   },
-
-  regularArray: {
-    code: 'uint256[] public arr;',
-    errorsImplicit: 1,
-    errorsExplicit: 0,
+  castInArrayDeclaration: {
+    implicit: 'uint256[] public arr = [uint(1),2,3];',
+    explicit: 'uint256[] public arr = [uint256(1),2,3];',
   },
-
-  fixedArray: {
-    code: 'uint[] public arr = [1,2,3];',
-    errorsImplicit: 0,
-    errorsExplicit: 1,
-  },
-
-  fixedArrayCastInDeclaration: {
-    code: 'uint[] public arr = [uint(1),2,3];',
-    errorsImplicit: 0,
-    errorsExplicit: 2,
-  },
-
-  fixedArrayOfArrays: {
-    code: 'uint256[] public arr = [[1,2,3]];',
-    errorsImplicit: 1,
-    errorsExplicit: 0,
-  },
-
-  mapOfFixedArray: {
-    code: 'uint[] public arr = [1,2,3]; mapping(uint256 => arr) mapOfFixedArray;',
-    errorsImplicit: 1,
-    errorsExplicit: 1,
-  },
-
   castInStateVariableDeclaration: {
-    code: 'uint256 public varUint256 = uint256(1); uint public varUint = uint(1);',
-    errorsImplicit: 2,
-    errorsExplicit: 2,
+    implicit: 'uint256 public varUint256 = uint(1);',
+    explicit: 'uint256 public varUint = uint256(1);',
   },
-
   castInsideFunctionAtDeclarationUint256: {
-    code: 'function withUint256() external { uint256 varUint256 = uint256(1); }',
-    errorsImplicit: 2,
-    errorsExplicit: 0,
+    implicit: 'function withUint256() external { uint256 varUint256 = uint(1); }',
+    explicit: 'function withUint256() external { uint256 varUint256 = uint256(1); }',
   },
-
-  castInsideFunctionAtDeclarationUint: {
-    code: 'function withUint() external { uint varUint = uint(1); }',
-    errorsImplicit: 0,
-    errorsExplicit: 2,
-  },
-
-  castInsideFunctionUint: {
-    code: 'function withUint() external { uint varUint; varUint = uint(1);}',
-    errorsImplicit: 0,
-    errorsExplicit: 2,
-  },
-
-  castInsideFunctionUint256: {
-    code: 'function withUint256() external { uint256 varUint; varUint = uint256(1);}',
-    errorsImplicit: 2,
-    errorsExplicit: 0,
-  },
-
-  castInsideModifier: {
-    code: 'modifier withUint256() { _; uint256 varUint; varUint = uint256(1);}',
-    errorsImplicit: 2,
-    errorsExplicit: 0,
+  castInExpressionStatement: {
+    implicit: 'function withUint() external { uint256 varUint; varUint = uint(1);}',
+    explicit: 'function withUint() external { uint256 varUint; varUint = uint256(1);}',
   },
 }
 

--- a/test/fixtures/best-practises/explicit-types.js
+++ b/test/fixtures/best-practises/explicit-types.js
@@ -19,6 +19,10 @@ const VAR_DECLARATIONS = {
   },
 
   // Here I try to be sure I don't miss places where a type can be used
+  memoryArrayCreation: {
+    explicit: 'function foo() public {uint256[] memory arr = new uint256[](5);}',
+    implicit: 'function foo() public {uint256[] memory arr = new uint[](5);}',
+  },
   functionParameterUint256: {
     explicit: 'function withUint256(uint256 varUint256) public {}',
     implicit: 'function withUint256(uint varUint256) public {}',

--- a/test/rules/best-practises/explicit-types.js
+++ b/test/rules/best-practises/explicit-types.js
@@ -1,0 +1,88 @@
+const linter = require('../../../lib/index')
+const contractWith = require('../../common/contract-builder').contractWith
+const { assertErrorCount, assertNoErrors, assertErrorMessage } = require('../../common/asserts')
+const VAR_DECLARATIONS = require('../../fixtures/best-practises/explicit-types')
+
+const getZeroErrosObject = () => {
+  const zeroErrorsExplicit = {}
+  const zeroErrorsImplicit = {}
+  for (const key in VAR_DECLARATIONS) {
+    const obj = VAR_DECLARATIONS[key]
+    if (obj.errorsImplicit === 0) {
+      zeroErrorsImplicit[key] = obj
+    }
+    if (obj.errorsExplicit === 0) {
+      zeroErrorsExplicit[key] = obj
+    }
+  }
+
+  return { zeroErrorsImplicit, zeroErrorsExplicit }
+}
+
+describe('Linter - explicit-types rule', () => {
+  it('should throw an error with a wrong configuration rule', () => {
+    const code = contractWith('uint256 public constant SNAKE_CASE = 1;')
+
+    const report = linter.processStr(code, {
+      rules: { 'explicit-types': ['error', 'implicito'] },
+    })
+
+    assertErrorCount(report, 1)
+    assertErrorMessage(report, `Error: Config error on [explicit-types]. See explicit-types.md.`)
+  })
+
+  it('should NOT throw error without the config array and default should take place', () => {
+    const code = contractWith('uint256 public constant SNAKE_CASE = 1;')
+    const report = linter.processStr(code, {
+      rules: { 'explicit-types': 'error' },
+    })
+
+    assertNoErrors(report)
+  })
+
+  for (const key in VAR_DECLARATIONS) {
+    it(`should raise error for ${key} on 'implicit' mode`, () => {
+      const { code, errorsImplicit } = VAR_DECLARATIONS[key]
+      const report = linter.processStr(contractWith(code), {
+        rules: { 'explicit-types': ['error', 'implicit'] },
+      })
+      assertErrorCount(report, errorsImplicit)
+      if (errorsImplicit > 0) assertErrorMessage(report, `Rule is set with implicit type [var/s:`)
+    })
+  }
+
+  for (const key in VAR_DECLARATIONS) {
+    it(`should raise error for ${key} on 'explicit' mode`, () => {
+      const { code, errorsExplicit } = VAR_DECLARATIONS[key]
+      const report = linter.processStr(contractWith(code), {
+        rules: { 'explicit-types': ['error', 'explicit'] },
+      })
+      assertErrorCount(report, errorsExplicit)
+      if (errorsExplicit > 0) assertErrorMessage(report, `Rule is set with explicit type [var/s:`)
+    })
+  }
+
+  describe('Rule [explicit-types] - should not raise any error', () => {
+    const { zeroErrorsImplicit, zeroErrorsExplicit } = getZeroErrosObject()
+
+    for (const key in zeroErrorsExplicit) {
+      it(`should NOT raise error for ${key} on 'implicit' mode`, () => {
+        const { code } = zeroErrorsExplicit[key]
+        const report = linter.processStr(contractWith(code), {
+          rules: { 'explicit-types': ['error', 'explicit'] },
+        })
+        assertNoErrors(report)
+      })
+    }
+
+    for (const key in zeroErrorsImplicit) {
+      it(`should NOT raise error for ${key} on 'implicit' mode`, () => {
+        const { code } = zeroErrorsImplicit[key]
+        const report = linter.processStr(contractWith(code), {
+          rules: { 'explicit-types': ['error', 'implicit'] },
+        })
+        assertNoErrors(report)
+      })
+    }
+  })
+})

--- a/test/rules/best-practises/explicit-types.js
+++ b/test/rules/best-practises/explicit-types.js
@@ -18,6 +18,23 @@ describe('Linter - explicit-types rule', () => {
     assertErrorCount(report, 2)
   })
 
+  it('should report correct line for initializer of a variable declaration', function () {
+    const code = `                            // 1
+      contract Foo {                          // 2
+          function foo() {                    // 3
+              uint256 complexThing = uint256( // 4
+                  uint(420)                   // 5
+              );                              // 6
+          }
+      }
+    `
+    const report = linter.processStr(code, {
+      rules: { 'explicit-types': 'error' },
+    })
+    assertErrorCount(report, 1)
+    assertLineNumber(report.reports[0], 5)
+  })
+
   for (const key in FIXTURE) {
     it(`should raise error for ${key} when using an implicit type`, () => {
       const { implicit } = FIXTURE[key]

--- a/test/rules/best-practises/explicit-types.js
+++ b/test/rules/best-practises/explicit-types.js
@@ -37,12 +37,19 @@ describe('Linter - explicit-types rule', () => {
 
   for (const key in FIXTURE) {
     it(`should raise error for ${key} when using an implicit type`, () => {
-      const { implicit } = FIXTURE[key]
+      const { implicit, implicitTypeName, explicitTypeName } = FIXTURE[key]
       const report = linter.processStr(contractWith(implicit), {
         rules: { 'explicit-types': 'error' },
       })
       assertErrorCount(report, 1)
-      assertErrorMessage(report, 'prefer use of explicit type')
+      if (explicitTypeName && implicitTypeName) {
+        assertErrorMessage(
+          report,
+          `prefer use of explicit type ${explicitTypeName} over ${implicitTypeName}`
+        )
+      } else {
+        assertErrorMessage(report, 'prefer use of explicit type')
+      }
     })
 
     it(`should NOT raise error for ${key} when using an explicit type`, () => {


### PR DESCRIPTION
originally implemented in https://github.com/protofire/solhint/pull/467 and patched in https://github.com/protofire/solhint/pull/493 and https://github.com/protofire/solhint/pull/481

I chose to checkout the files as they are on 354ae8b37b8cd01596b7e3d9e1d19ce02d96e44e (today's protofire/solhint/develop) and then add whatever changes are necessary on top to give some attrbution but not have to deal with cherry-picking and potentially ammending upstream's git history