### PR TITLE
update compiler-version to current solc version

### DIFF
--- a/conf/rulesets/solhint-all.js
+++ b/conf/rulesets/solhint-all.js
@@ -53,7 +53,7 @@ module.exports = Object.freeze({
     'avoid-throw': 'warn',
     'avoid-tx-origin': 'warn',
     'check-send-result': 'warn',
-    'compiler-version': ['error', '^0.5.8'],
+    'compiler-version': ['error', '^0.8.14'],
     'func-visibility': [
       'warn',
       {

--- a/conf/rulesets/solhint-recommended.js
+++ b/conf/rulesets/solhint-recommended.js
@@ -34,7 +34,7 @@ module.exports = Object.freeze({
     'avoid-throw': 'warn',
     'avoid-tx-origin': 'warn',
     'check-send-result': 'warn',
-    'compiler-version': ['error', '^0.5.8'],
+    'compiler-version': ['error', '^0.8.14'],
     'func-visibility': [
       'warn',
       {

--- a/docs/rules/security/compiler-version.md
+++ b/docs/rules/security/compiler-version.md
@@ -20,14 +20,14 @@ This rule accepts an array of options:
 | Index | Description                                           | Default Value |
 | ----- | ----------------------------------------------------- | ------------- |
 | 0     | Rule severity. Must be one of "error", "warn", "off". | error         |
-| 1     | Semver requirement                                    | ^0.5.8        |
+| 1     | Semver requirement                                    | ^0.8.14       |
 
 
 ### Example Config
 ```json
 {
   "rules": {
-    "compiler-version": ["error","^0.5.8"]
+    "compiler-version": ["error","^0.8.14"]
   }
 }
 ```

--- a/lib/config.js
+++ b/lib/config.js
@@ -15,11 +15,6 @@ module.exports = {
     return _.isBoolean(configVal) ? configVal : defaultValue
   },
 
-  getStringByPath(path, defaultValue) {
-    const configVal = _.get(this, path)
-    return _.isString(configVal) ? configVal : defaultValue
-  },
-
   getNumber(ruleName, defaultValue) {
     return this.getNumberByPath(`rules["${ruleName}"][1]`, defaultValue)
   },
@@ -33,7 +28,14 @@ module.exports = {
   },
 
   getString(ruleName, defaultValue) {
-    return this.getStringByPath(`rules["${ruleName}"][1]`, defaultValue)
+    const configRoot = _.get(this, `rules["${ruleName}"]`)
+    if (_.isArray(configRoot)) {
+      const configVal = _.get(this, `rules["${ruleName}"][1]`)
+      if (_.isString(configVal)) {
+        return configVal
+      }
+    }
+    return defaultValue
   },
 
   getArray(ruleName, defaultValue) {

--- a/lib/rules/security/compiler-version.js
+++ b/lib/rules/security/compiler-version.js
@@ -4,7 +4,7 @@ const { severityDescription } = require('../../doc/utils')
 
 const ruleId = 'compiler-version'
 const DEFAULT_SEVERITY = 'error'
-const DEFAULT_SEMVER = '^0.5.8'
+const DEFAULT_SEMVER = '^0.8.14'
 const meta = {
   type: 'security',
 

--- a/test/rules/best-practises/no-global-import.js
+++ b/test/rules/best-practises/no-global-import.js
@@ -28,10 +28,11 @@ describe('Linter - no-global-import', () => {
     assertErrorMessage(report, 'Specify names to import individually')
   })
   it('should raise warning when using solhint:recommended', () => {
-    const code = `pragma solidity ^0.5.8; import "./A.sol";`
+    const code = `import "./A.sol";`
 
     const report = linter.processStr(code, {
       extends: 'solhint:recommended',
+      rules: { 'compiler-version': 'off' },
     })
     assertWarnsCount(report, 1)
     assertErrorMessage(report, 'global import')

--- a/test/rules/best-practises/no-unused-import.js
+++ b/test/rules/best-practises/no-unused-import.js
@@ -48,10 +48,11 @@ describe('Linter - no-unused-import', () => {
   })
 
   it('should raise error when using solhint:recommended', () => {
-    const code = `pragma solidity ^0.5.8; import {A} from "./A.sol";`
+    const code = `import {A} from "./A.sol";`
 
     const report = linter.processStr(code, {
       extends: 'solhint:recommended',
+      rules: { 'compiler-version': 'off' },
     })
     assertWarnsCount(report, 1)
     assertErrorMessage(report, 'imported name A is not used')

--- a/test/rules/security/compiler-version.js
+++ b/test/rules/security/compiler-version.js
@@ -202,4 +202,20 @@ describe('Linter - compiler-version', () => {
 
     assert.equal(report.errorCount, 0)
   })
+
+  it(`should not report error with version 0.8.14 and no options`, () => {
+    const report = linter.processStr(`pragma solidity ^0.8.14;`, {
+      rules: { 'compiler-version': 'error' },
+    })
+
+    assertNoErrors(report)
+  })
+
+  it(`should report error with version 0.8.13 and no options`, () => {
+    const report = linter.processStr(`pragma solidity ^0.8.13;`, {
+      rules: { 'compiler-version': 'error' },
+    })
+
+    assertErrorCount(report, 1)
+  })
 })


### PR DESCRIPTION
I scrolled https://github.com/ethereum/solidity/releases until I found the first one with an 'important' bugfix. This is ideally the oldest version you should use out of security concerns

I also fixed a bug in `getString` since when not providing an option, instead of returning null or the default value, it returned the second element of the severity string, 'r' for error 🙃