### PR TITLE
E2e test stdin subcommand

### DIFF
--- a/e2e/09-fixers/disabled-rules.json
+++ b/e2e/09-fixers/disabled-rules.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "avoid-sha3": "off",
+    "avoid-throw": "off"
+  }
+}

--- a/e2e/09-fixers/error-warning.json
+++ b/e2e/09-fixers/error-warning.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "avoid-sha3": "error",
+    "compiler-version": "warn",
+    "avoid-throw": "error"
+  }
+}

--- a/e2e/09-fixers/ignore-throw-error
+++ b/e2e/09-fixers/ignore-throw-error
@@ -1,0 +1,1 @@
+throw-error.sol

--- a/e2e/09-fixers/two-errors.json
+++ b/e2e/09-fixers/two-errors.json
@@ -1,0 +1,7 @@
+{
+  "rules": {
+    "avoid-sha3": "error",
+    "compiler-version": "error",
+    "avoid-throw": "error"
+  }
+}

--- a/e2e/09-fixers/warning-rules.json
+++ b/e2e/09-fixers/warning-rules.json
@@ -1,0 +1,6 @@
+{
+  "rules": {
+    "avoid-sha3": "warn",
+    "avoid-throw": "warn"
+  }
+}

--- a/e2e/fixers.js
+++ b/e2e/fixers.js
@@ -9,7 +9,7 @@ describe('e2e tests fixers', function () {
     useFixture('09-fixers')
 
     it('GIVEN a file with a throw usage on disk WHEN fixing THEN it is replaced with revert', () => {
-      const { code } = shell.exec('solhint --fix throw-error.sol')
+      const { code } = shell.exec('solhint --fix throw-error.sol', { silent: true })
       expect(code).to.equal(0)
       expect(getFixtureFileContentSync('throw-error.sol')).to.eq(
         getFixtureFileContentSync('throw-fixed.sol')
@@ -21,7 +21,7 @@ describe('e2e tests fixers', function () {
     useFixture('09-fixers')
 
     it('GIVEN a file with a sha3 usage on disk WHEN fixing THEN it is replaced with keccak256', () => {
-      const { code } = shell.exec('solhint --fix sha3-error.sol')
+      const { code } = shell.exec('solhint --fix sha3-error.sol', { silent: true })
       expect(code).to.equal(0)
       expect(getFixtureFileContentSync('sha3-error.sol')).to.eq(
         getFixtureFileContentSync('sha3-fixed.sol')

--- a/e2e/fixers.js
+++ b/e2e/fixers.js
@@ -15,6 +15,15 @@ describe('e2e tests fixers', function () {
         getFixtureFileContentSync('throw-fixed.sol')
       )
     })
+
+    it('GIVEN a file with a throw usage on stdin WHEN fixing THEN it is replaced with revert on stdout', () => {
+      const { code, stdout } = shell.exec(
+        'solhint stdin --fix --filename foo.sol < throw-error.sol',
+        { silent: true }
+      )
+      expect(code).to.equal(0)
+      expect(stdout.trim()).to.eq(getFixtureFileContentSync('throw-fixed.sol').trim())
+    })
   })
 
   describe('avoid-sha3', () => {

--- a/e2e/formatters.js
+++ b/e2e/formatters.js
@@ -5,7 +5,7 @@ const { useFixture } = require('./utils')
 describe('formatters', function () {
   useFixture('03-no-empty-blocks')
   it('unix', async function () {
-    const { stdout } = shell.exec('solhint Foo.sol --formatter unix')
+    const { stdout } = shell.exec('solhint Foo.sol --formatter unix', { silent: true })
     const lines = stdout.split('\n')
     expect(lines[0]).to.eq('Foo.sol:3:1: Code contains empty blocks [Error/no-empty-blocks]')
     expect(lines[2].trim()).to.eq('1 problem')
@@ -14,7 +14,7 @@ describe('formatters', function () {
   describe('json', function () {
     let stdout
     beforeEach(function () {
-      ;({ stdout } = shell.exec('solhint Foo.sol --formatter json'))
+      ;({ stdout } = shell.exec('solhint Foo.sol --formatter json', { silent: true }))
     })
     it('is proper json and not a JS object', async function () {
       expect(stdout).to.contain('"message"')
@@ -40,7 +40,7 @@ describe('formatters', function () {
   })
 
   it('tap', async function () {
-    const { stdout } = shell.exec('solhint Foo.sol --formatter tap')
+    const { stdout } = shell.exec('solhint Foo.sol --formatter tap', { silent: true })
     const lines = stdout.split('\n')
 
     expect(lines[0]).to.eq('TAP version 13')
@@ -56,7 +56,7 @@ describe('formatters', function () {
   })
 
   it('stylish', async function () {
-    const { stdout } = shell.exec('solhint Foo.sol --formatter stylish')
+    const { stdout } = shell.exec('solhint Foo.sol --formatter stylish', { silent: true })
     const lines = stdout.split('\n')
 
     expect(lines[1]).to.eq('Foo.sol')
@@ -65,7 +65,7 @@ describe('formatters', function () {
   })
 
   it('compact', async function () {
-    const { stdout } = shell.exec('solhint Foo.sol --formatter compact')
+    const { stdout } = shell.exec('solhint Foo.sol --formatter compact', { silent: true })
     const lines = stdout.split('\n')
     expect(lines[0]).to.eq(
       'Foo.sol: line 3, col 1, Error - Code contains empty blocks (no-empty-blocks)'
@@ -74,7 +74,7 @@ describe('formatters', function () {
   })
 
   it('table', async function () {
-    const { stdout } = shell.exec('solhint Foo.sol --formatter table')
+    const { stdout } = shell.exec('solhint Foo.sol --formatter table', { silent: true })
     const lines = stdout.split('\n')
 
     expect(lines[1]).to.eq('Foo.sol')

--- a/e2e/rules.js
+++ b/e2e/rules.js
@@ -11,7 +11,7 @@ describe('e2e tests for rules', function () {
     useFixture('03-no-empty-blocks')
 
     it('should exit with 1', function () {
-      const { code, stdout } = shell.exec('solhint Foo.sol')
+      const { code, stdout } = shell.exec('solhint Foo.sol', { silent: true })
       expect(code).to.equal(1)
       expect(stdout.trim()).to.contain('Code contains empty blocks')
     })
@@ -40,7 +40,9 @@ describe('e2e tests for rules', function () {
     useFixture('07-foundry-test')
 
     it(`should raise error for wrongFunctionDefinitionName() only`, () => {
-      const { code, stdout } = shell.exec('solhint -c test/.solhint.json test/FooTest.sol')
+      const { code, stdout } = shell.exec('solhint -c test/.solhint.json test/FooTest.sol', {
+        silent: true,
+      })
 
       expect(code).to.equal(1)
       expect(stdout.trim()).to.contain(

--- a/e2e/stdin.js
+++ b/e2e/stdin.js
@@ -1,0 +1,306 @@
+/* eslint-disable prefer-arrow-callback */
+
+const { expect } = require('chai')
+const shell = require('shelljs')
+const { useFixture, getFixtureFileContentSync } = require('./utils')
+
+describe('e2e: stdin subcommand', function () {
+  useFixture('09-fixers')
+  let code
+  let stdout
+  let stderr
+  describe('WHEN passing --init ', function () {
+    let originalConfig
+    beforeEach(function () {
+      originalConfig = getFixtureFileContentSync('.solhint.json')
+      ;({ code, stdout, stderr } = shell.exec('solhint stdin --init < throw-error.sol', {
+        silent: true,
+      }))
+    })
+    it('THEN it is silently ignored', function () {
+      expect(code).to.eq(1)
+      expect(stderr).not.to.include('Configuration file created')
+      expect(stdout).not.to.include('Configuration file created')
+      expect(stderr).not.to.include('Configuration file already exists')
+      expect(stdout).not.to.include('Configuration file already exists')
+      expect(getFixtureFileContentSync('.solhint.json')).to.eq(originalConfig)
+    })
+  })
+
+  describe('WHEN passing --ignore-path ', function () {
+    beforeEach(function () {
+      ;({ code, stdout, stderr } = shell.exec(
+        'solhint stdin --ignore-path ignore-throw-error --filename throw-error.sol < throw-error.sol',
+        {
+          silent: true,
+        }
+      ))
+    })
+    it('THEN it is silently ignored', function () {
+      expect(code).to.eq(1)
+      expect(stdout).to.include('3:9  error')
+    })
+  })
+
+  describe('--quiet is respected', function () {
+    describe('WHEN checking a file with one warning and one error AND using --quiet', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec(
+          'solhint stdin -c error-warning.json -q < throw-error.sol',
+          { silent: true }
+        ))
+      })
+      it('THEN it exits with code 1', function () {
+        expect(code).to.eq(1)
+      })
+      it('AND reports only one problem', function () {
+        expect(stdout).to.include('1 problem')
+        expect(stdout).to.include('1 error')
+        expect(stdout).to.include('0 warnings')
+      })
+    })
+  })
+
+  describe('--quiet drops warnings so --max-warnings has no effect', function () {
+    describe('WHEN checking a file with one warning AND using --quiet AND using --max-warnings 0', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec(
+          'solhint stdin -c warning-rules.json -q -w 0 < throw-error.sol',
+          { silent: true }
+        ))
+      })
+      it('THEN it exits with code 0', function () {
+        expect(code).to.eq(0)
+      })
+      it('AND it does NOT print the warning messages', function () {
+        expect(stdout).not.to.include('3:9  warning')
+        expect(stdout).not.to.include('3:9  error')
+      })
+      it('AND it does NOT print the too many warnings message', function () {
+        expect(stdout).not.to.include('found more warnings than the maximum')
+      })
+    })
+  })
+
+  describe('--filename value is used for report ', () => {
+    describe('WHEN running the linter on a file with an error on stdin', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec('solhint stdin < throw-error.sol', {
+          silent: true,
+        }))
+      })
+      it('THEN it exits with code 1', function () {
+        expect(code).to.eq(1)
+      })
+      it("AND reports an error on file 'stdin' ", function () {
+        expect(stdout).to.include('stdin')
+        expect(stdout).to.include('3:9  error')
+        expect(stdout).to.include('1 error')
+      })
+    })
+
+    describe('WHEN running the linter on a stdin stream with an error AND passing --filename pointing to a file without errors', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec(
+          'solhint stdin --filename throw-fixed.sol < throw-error.sol',
+          {
+            silent: true,
+          }
+        ))
+      })
+
+      it('THEN it exits with code 1, showing stdin and not the file on disk is read', function () {
+        expect(code).to.eq(1)
+      })
+    })
+
+    describe('WHEN running the linter on a file with an error on stdin AND passing --filename', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec('solhint stdin --filename foo.sol < throw-error.sol', {
+          silent: true,
+        }))
+      })
+
+      it('THEN it exits with code 1', function () {
+        expect(code).to.eq(1)
+      })
+      it("AND reports an error on file 'foo.sol' ", function () {
+        expect(stdout).to.include('foo.sol')
+        expect(stdout).to.include('3:9  error')
+        expect(stdout).to.include('1 error')
+      })
+    })
+  })
+
+  describe('--formatter is used', () => {
+    describe('WHEN running the linter on a file with an error on stdin AND choosing the unix formatter', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec('solhint stdin --formatter unix < throw-error.sol', {
+          silent: true,
+        }))
+      })
+
+      it('THEN it exits with code 1', function () {
+        expect(code).to.eq(1)
+      })
+      it("AND reports an error on file 'stdin' with unix format ", function () {
+        expect(stdout).to.include('stdin:3:9: "throw" is deprecated')
+        expect(stdout).to.include('1 problem')
+      })
+    })
+  })
+
+  describe('--config is used', () => {
+    describe('WHEN running the linter on a file with an error on stdin AND a config file that disables the rule for said error', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec(
+          'solhint stdin --config disabled-rules.json < throw-error.sol',
+          { silent: true }
+        ))
+      })
+
+      it('THEN it exits with code 0', function () {
+        expect(code).to.eq(0)
+      })
+      it('AND reports no errors', function () {
+        expect(stdout.trim()).to.eq('')
+      })
+    })
+  })
+
+  describe('--max-warnings is used', () => {
+    describe('WHEN running the linter on a file with a warning', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec(
+          'solhint stdin --config warning-rules.json < throw-error.sol',
+          { silent: true }
+        ))
+      })
+
+      it('THEN it exits with code 0', function () {
+        expect(code).to.eq(0)
+      })
+      it('AND reports one warning', function () {
+        expect(stdout).to.include('1 warning')
+      })
+    })
+
+    describe('WHEN running the linter on a file with a warning AND --max-warnings 0', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec(
+          'solhint stdin --config warning-rules.json --max-warnings 0 < throw-error.sol',
+          { silent: true }
+        ))
+      })
+
+      it('THEN it exits with code 1', function () {
+        expect(code).to.eq(1)
+      })
+      it('AND reports one warning', function () {
+        expect(stdout).to.include('1 warning')
+        expect(stdout).to.include('found more warnings than the maximum')
+      })
+    })
+  })
+
+  describe('--fix triggers filter mode', () => {
+    describe('WHEN running as a fixer on a stdin stream with only one fixable error', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec('solhint stdin --fix < throw-error.sol', { silent: true }))
+      })
+      it('THEN it exits with code 0', function () {
+        expect(code).to.eq(0)
+      })
+      it('AND outputs the fixed file', function () {
+        expect(stdout.trim()).to.eq(getFixtureFileContentSync('throw-fixed.sol').trim())
+      })
+    })
+
+    describe('WHEN running as a fixer on a stdin stream with one fixable and one non-fixable error', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec(
+          'solhint stdin --fix -c two-errors.json < throw-error.sol',
+          { silent: true }
+        ))
+      })
+      it('THEN it exits with code 1', function () {
+        expect(code).to.eq(1)
+      })
+      it('AND outputs the (partially) fixed file', function () {
+        expect(stdout.trim()).to.eq(getFixtureFileContentSync('throw-fixed.sol').trim())
+      })
+    })
+
+    describe('WHEN running as a fixer on a stdin stream with only one fixable error AND the --filename parameter points to the file on disk', function () {
+      let originalFile
+      beforeEach(function () {
+        originalFile = getFixtureFileContentSync('throw-error.sol')
+        ;({ code, stdout } = shell.exec(
+          'solhint stdin --fix --filename throw-error.sol < throw-error.sol',
+          { silent: true }
+        ))
+      })
+      it('THEN it exits with code 0', function () {
+        expect(code).to.eq(0)
+      })
+      it('AND outputs the fixed file', function () {
+        expect(stdout.trim()).to.eq(getFixtureFileContentSync('throw-fixed.sol').trim())
+      })
+      it('AND the original file is left alone', function () {
+        expect(getFixtureFileContentSync('throw-error.sol')).to.eq(originalFile)
+      })
+    })
+
+    describe('exit code depends on --max-warnings but extra message isnt printed', function () {
+      describe('WHEN fixing a file with --max-warnings 0 and one warning', function () {
+        beforeEach(function () {
+          ;({ code, stdout } = shell.exec(
+            'solhint stdin --fix -c error-warning.json --max-warnings 0 < throw-error.sol',
+            { silent: true }
+          ))
+        })
+        it('THEN it exits with code 1', function () {
+          expect(code).to.eq(1)
+        })
+        it('AND outputs the fixed file', function () {
+          expect(stdout.trim()).to.eq(getFixtureFileContentSync('throw-fixed.sol').trim())
+        })
+        it('AND does NOT print too many warnings message', function () {
+          expect(stdout.trim()).to.not.include('more warnings')
+        })
+      })
+    })
+
+    describe('--quiet and --max-warnings behaves in the same way as when linting, but fixes possible warnings', function () {
+      describe('WHEN fixing a file with --max-warnings 0 AND one warning AND --quiet', function () {
+        beforeEach(function () {
+          ;({ code, stdout } = shell.exec(
+            'solhint stdin --fix --quiet -c error-warning.json --max-warnings 0 < throw-error.sol',
+            { silent: true }
+          ))
+        })
+        it('THEN it exits with code 0 since warnings are ignored', function () {
+          expect(code).to.eq(0)
+        })
+        it('AND outputs the fixed file', function () {
+          expect(stdout.trim()).to.eq(getFixtureFileContentSync('throw-fixed.sol').trim())
+        })
+      })
+
+      describe('WHEN fixing a file with one warning AND --quiet', function () {
+        beforeEach(function () {
+          ;({ code, stdout } = shell.exec(
+            'solhint stdin --fix --quiet -c error-warning.json < throw-error.sol',
+            { silent: true }
+          ))
+        })
+        it('THEN it exits with code 0 since warnings are ignored', function () {
+          expect(code).to.eq(0)
+        })
+        it('AND outputs the fixed file', function () {
+          expect(stdout.trim()).to.eq(getFixtureFileContentSync('throw-fixed.sol').trim())
+        })
+      })
+    })
+  })
+})

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -10,24 +10,24 @@ describe('main executable tests', function () {
     useFixture('01-no-config')
     describe('GIVEN a config file created with solhint --init', function () {
       beforeEach(function () {
-        shell.exec('solhint --init')
+        shell.exec('solhint --init', { silent: true })
       })
 
       it('WHEN linting a file, THEN the config is used ', function () {
-        const { code, stdout } = shell.exec('solhint Foo.sol')
+        const { code, stdout } = shell.exec('solhint Foo.sol', { silent: true })
         expect(code).to.equal(1)
         expect(stdout.trim()).to.contain('Code contains empty blocks')
       })
     })
 
     it('should fail', function () {
-      const { code } = shell.exec('solhint Foo.sol')
+      const { code } = shell.exec('solhint Foo.sol', { silent: true })
 
       expect(code).to.equal(1)
     })
 
     it('should create an initial config with --init', function () {
-      const { code } = shell.exec('solhint --init')
+      const { code } = shell.exec('solhint --init', { silent: true })
 
       expect(code).to.equal(0)
 
@@ -37,7 +37,7 @@ describe('main executable tests', function () {
     })
 
     it('should print usage if called without arguments', function () {
-      const { code, stdout } = shell.exec('solhint')
+      const { code, stdout } = shell.exec('solhint', { silent: true })
 
       expect(code).to.equal(0)
 
@@ -51,7 +51,7 @@ describe('main executable tests', function () {
     useFixture('02-empty-solhint-json')
 
     it('should print nothing', function () {
-      const { code, stdout } = shell.exec('solhint Foo.sol')
+      const { code, stdout } = shell.exec('solhint Foo.sol', { silent: true })
 
       expect(code).to.equal(0)
 
@@ -59,7 +59,7 @@ describe('main executable tests', function () {
     })
 
     it('should show warning when using --init', function () {
-      const { code, stdout } = shell.exec('solhint --init')
+      const { code, stdout } = shell.exec('solhint --init', { silent: true })
 
       expect(code).to.equal(0)
 
@@ -71,7 +71,7 @@ describe('main executable tests', function () {
     useFixture('04-dotSol-on-path')
 
     it('should handle directory names that end with .sol', function () {
-      const { code } = shell.exec('solhint contracts/**/*.sol')
+      const { code } = shell.exec('solhint contracts/**/*.sol', { silent: true })
 
       expect(code).to.equal(0)
     })
@@ -87,7 +87,8 @@ describe('main executable tests', function () {
       describe('WHEN linting with --max-warnings 7 ', function () {
         beforeEach(function () {
           ;({ code, stdout } = shell.exec(
-            'solhint contracts/NoErrors6Warnings.sol --max-warnings 7'
+            'solhint contracts/NoErrors6Warnings.sol --max-warnings 7',
+            { silent: true }
           ))
         })
         it('THEN it does NOT display warnings exceeded message', function () {
@@ -101,7 +102,8 @@ describe('main executable tests', function () {
       describe('WHEN linting with --max-warnings 3 ', function () {
         beforeEach(function () {
           ;({ code, stdout } = shell.exec(
-            'solhint contracts/NoErrors6Warnings.sol --max-warnings 3'
+            'solhint contracts/NoErrors6Warnings.sol --max-warnings 3',
+            { silent: true }
           ))
         })
         it('THEN displays warnings exceeded message', function () {
@@ -117,7 +119,8 @@ describe('main executable tests', function () {
       describe('WHEN linting with --max-warnings 3 ', function () {
         beforeEach(function () {
           ;({ code, stdout } = shell.exec(
-            'solhint contracts/OneError14Warnings.sol --max-warnings 3'
+            'solhint contracts/OneError14Warnings.sol --max-warnings 3',
+            { silent: true }
           ))
         })
         it('THEN it exits error code 1', function () {
@@ -139,7 +142,7 @@ describe('main executable tests', function () {
       useFixture('08-list-rules')
       describe('WHEN executing with list-rules', function () {
         beforeEach(function () {
-          ;({ code, stdout } = shell.exec('solhint list-rules'))
+          ;({ code, stdout } = shell.exec('solhint list-rules', { silent: true }))
         })
         it('THEN it completes without error', function () {
           expect(code).to.equal(0)
@@ -158,7 +161,10 @@ describe('main executable tests', function () {
       useFixture('08-list-rules')
       describe('WHEN executing with list-rules -c config-file-with-weird-name.json', function () {
         beforeEach(function () {
-          ;({ code, stdout } = shell.exec('solhint list-rules -c config-file-with-weird-name.json'))
+          ;({ code, stdout } = shell.exec(
+            'solhint list-rules -c config-file-with-weird-name.json',
+            { silent: true }
+          ))
         })
         it('THEN it completes without error', function () {
           expect(code).to.equal(0)
@@ -180,7 +186,8 @@ describe('main executable tests', function () {
       describe('WHEN executing with list-rules', function () {
         beforeEach(function () {
           ;({ code, stdout, stderr } = shell.exec(
-            'solhint list-rules -c config-file-with-weird-name.json'
+            'solhint list-rules -c config-file-with-weird-name.json',
+            { silent: true }
           ))
         })
         it('THEN it returns error code 1', function () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "antlr4": "^4.11.0",
         "ast-parents": "^0.0.1",
         "chalk": "^4.1.2",
-        "commander": "^10.0.0",
+        "commander": "^11.1.0",
         "cosmiconfig": "^8.0.0",
         "fast-diff": "^1.2.0",
         "glob": "^8.0.3",
@@ -1244,11 +1244,11 @@
       }
     },
     "node_modules/commander": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.0.tgz",
-      "integrity": "sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
       "engines": {
-        "node": ">=14"
+        "node": ">=16"
       }
     },
     "node_modules/commondir": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "antlr4": "^4.11.0",
     "ast-parents": "^0.0.1",
     "chalk": "^4.1.2",
-    "commander": "^10.0.0",
+    "commander": "^11.1.0",
     "cosmiconfig": "^8.0.0",
     "fast-diff": "^1.2.0",
     "glob": "^8.0.3",

--- a/solhint.js
+++ b/solhint.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const program = require('commander')
+const { Command } = require('commander')
 const _ = require('lodash')
 const fs = require('fs')
 const process = require('process')
@@ -12,11 +12,13 @@ const applyFixes = require('./lib/apply-fixes')
 const ruleFixer = require('./lib/rule-fixer')
 const packageJson = require('./package.json')
 
+const rootCommand = new Command()
+
 function init() {
   const version = packageJson.version
-  program.version(version)
+  rootCommand.version(version)
 
-  program
+  rootCommand
     .name('solhint')
     .usage('[options] <file> [...other_files]')
     .option(
@@ -32,30 +34,31 @@ function init() {
     .description('Linter for Solidity programming language')
     .action(execMainAction)
 
-  program
+  rootCommand
     .command('stdin')
     .description('linting of source code data provided to STDIN')
-    .option('--filename [file_name]', 'name of file received using STDIN')
+    .option('--filename <file_name>', 'name of file received using STDIN')
     .action(processStdin)
 
-  program
+  rootCommand
     .command('init-config', null, { noHelp: true })
     .description('create configuration file for solhint')
     .action(writeSampleConfigFile)
 
-  program
+  rootCommand
     .command('list-rules', null, { noHelp: false })
     .description('display enabled rules of current config')
     .action(listRules)
 
   if (process.argv.length <= 2) {
-    program.help()
+    rootCommand.help()
   }
-  program.parse(process.argv)
+
+  rootCommand.parse(process.argv)
 }
 
 function execMainAction() {
-  if (program.opts().init) {
+  if (rootCommand.opts().init) {
     writeSampleConfigFile()
   }
 
@@ -63,16 +66,16 @@ function execMainAction() {
 
   try {
     // to check if is a valid formatter before execute linter
-    formatterFn = getFormatter(program.opts().formatter)
+    formatterFn = getFormatter(rootCommand.opts().formatter)
   } catch (ex) {
     console.error(ex.message)
     process.exit(1)
   }
 
-  const reportLists = program.args.filter(_.isString).map(processPath)
+  const reportLists = rootCommand.args.filter(_.isString).map(processPath)
   const reports = _.flatten(reportLists)
 
-  if (program.opts().fix) {
+  if (rootCommand.opts().fix) {
     for (const report of reports) {
       const inputSrc = fs.readFileSync(report.filePath).toString()
 
@@ -90,7 +93,7 @@ function execMainAction() {
     }
   }
 
-  if (program.opts().quiet) {
+  if (rootCommand.opts().quiet) {
     // filter the list of reports, to set errors only.
     reports.forEach((reporter) => {
       reporter.reports = reporter.reports.filter((i) => i.severity === 2)
@@ -99,12 +102,13 @@ function execMainAction() {
   process.exit(consumeReport(reports, formatterFn))
 }
 
-function processStdin(options) {
+function processStdin(subcommandOptions) {
+  const allOptions = { ...rootCommand.opts(), ...subcommandOptions }
   const STDIN_FILE = 0
   const stdinBuffer = fs.readFileSync(STDIN_FILE)
 
   const report = processStr(stdinBuffer.toString())
-  report.file = options.filename || 'stdin'
+  report.file = allOptions.filename || 'stdin'
   const formatterFn = getFormatter()
 
   process.exit(consumeReport([report], formatterFn))
@@ -131,8 +135,8 @@ function writeSampleConfigFile() {
 const readIgnore = _.memoize(() => {
   let ignoreFile = '.solhintignore'
   try {
-    if (program.opts().ignorePath) {
-      ignoreFile = program.opts().ignorePath
+    if (rootCommand.opts().ignorePath) {
+      ignoreFile = rootCommand.opts().ignorePath
     }
 
     return fs
@@ -141,7 +145,7 @@ const readIgnore = _.memoize(() => {
       .split('\n')
       .map((i) => i.trim())
   } catch (e) {
-    if (program.opts().ignorePath && e.code === 'ENOENT') {
+    if (rootCommand.opts().ignorePath && e.code === 'ENOENT') {
       console.error(`\nERROR: ${ignoreFile} is not a valid path.`)
     }
     return []
@@ -152,7 +156,7 @@ const readConfig = _.memoize(() => {
   let config = {}
 
   try {
-    config = loadConfig(program.opts().config)
+    config = loadConfig(rootCommand.opts().config)
   } catch (e) {
     console.error(e.message)
     process.exit(1)
@@ -181,7 +185,7 @@ function getFormatter(formatter) {
     return require(`./lib/formatters/${formatterName}`)
   } catch (ex) {
     ex.message = `\nThere was a problem loading formatter option: ${
-      program.opts().formatter
+      rootCommand.opts().formatter
     } \nError: ${ex.message}`
     throw ex
   }
@@ -191,12 +195,12 @@ function consumeReport(reports, formatterFn) {
   const errorsCount = reports.reduce((acc, i) => acc + i.errorCount, 0)
   const warningCount = reports.reduce((acc, i) => acc + i.warningCount, 0)
   const tooManyWarnings =
-    program.opts().maxWarnings >= 0 && warningCount > program.opts().maxWarnings
+    rootCommand.opts().maxWarnings >= 0 && warningCount > rootCommand.opts().maxWarnings
   console.log(formatterFn(reports))
   if (tooManyWarnings && errorsCount === 0) {
     console.log(
       'Solhint found more warnings than the maximum specified (maximum: %s, found %s). This is an error.',
-      program.opts().maxWarnings,
+      rootCommand.opts().maxWarnings,
       warningCount
     )
   }


### PR DESCRIPTION
closes #69 
closes #70
closes #73 if we're not set on removing the subcommand itself

@llllvvuu iirc you were involved with writing solhint integrations for editors, so your input would be appreciated here. This for example includes a regression to make sure when running `solhint stdin --filename foo.sol < /tmp/editorThingy/foo.sol` , it's `/tmp/editorThinghy/foo.sol` that is read and not `foo.sol`, which afaict is not the case on protofire/solhint

Feel free to suggest improvements :sparkles: 