### PR TITLE
e2e tests for root command options

### DIFF
--- a/e2e/12-solhintignore/.solhint.json
+++ b/e2e/12-solhintignore/.solhint.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "avoid-throw": "error"
+  }
+}

--- a/e2e/12-solhintignore/.solhintignore
+++ b/e2e/12-solhintignore/.solhintignore
@@ -1,0 +1,1 @@
+IgnoredDefault.sol

--- a/e2e/12-solhintignore/IgnoredDefault.sol
+++ b/e2e/12-solhintignore/IgnoredDefault.sol
@@ -1,0 +1,5 @@
+contract ThrowError {
+    function doThing() public pure {
+        throw;
+    }
+}

--- a/e2e/12-solhintignore/IgnoredOther.sol
+++ b/e2e/12-solhintignore/IgnoredOther.sol
@@ -1,0 +1,5 @@
+contract ThrowError {
+    function doThing() public pure {
+        throw;
+    }
+}

--- a/e2e/12-solhintignore/NoErrors.sol
+++ b/e2e/12-solhintignore/NoErrors.sol
@@ -1,0 +1,5 @@
+contract ThrowError {
+    function doThing() public pure {
+        revert();
+    }
+}

--- a/e2e/12-solhintignore/other-solhintignore
+++ b/e2e/12-solhintignore/other-solhintignore
@@ -1,0 +1,1 @@
+IgnoredOther.sol

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -77,6 +77,179 @@ describe('main executable tests', function () {
     })
   })
 
+  // I used different config files and the same source file so it's testing both
+  // functionalities. Since they're regressions for features already in
+  // production, I'm gonna lean on being lazy for now and put something better
+  // in place when/if we get rid of the stdin subcommand
+  describe('--quiet and --config are respected', function () {
+    useFixture('09-fixers')
+    let code
+    let stdout
+    describe('WHEN checking a file with one warning and one error AND using --quiet', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec('solhint -c error-warning.json -q throw-error.sol', {
+          silent: true,
+        }))
+      })
+      it('THEN it exits with code 1', function () {
+        expect(code).to.eq(1)
+      })
+      it('AND reports only one problem', function () {
+        expect(stdout).to.include('1 problem')
+        expect(stdout).to.include('1 error')
+        expect(stdout).to.include('0 warnings')
+      })
+    })
+
+    describe('WHEN checking a file with only warnings AND using --quiet', function () {
+      beforeEach(function () {
+        ;({ code, stdout } = shell.exec('solhint -c warning-rules.json -q throw-error.sol', {
+          silent: true,
+        }))
+      })
+      it('THEN it exits with code 0', function () {
+        expect(code).to.eq(0)
+      })
+      it('AND reports no problems', function () {
+        expect(stdout.trim()).to.equal('')
+      })
+    })
+  })
+
+  describe('--ignore-path is used', function () {
+    describe('GIVEN IgnoredDefault.sol (1 error) and IgnoredOther.sol (1 error)', function () {
+      useFixture('12-solhintignore')
+      let code
+      let stdout
+      let stderr
+      describe('WHEN linting with --ignore-path pointing to a non-existent file AND that file has errors', function () {
+        beforeEach(function () {
+          ;({ code, stdout, stderr } = shell.exec(
+            'solhint --ignore-path does-not-exist IgnoredDefault.sol',
+            {
+              silent: true,
+            }
+          ))
+        })
+        it('THEN an error is printed to stderr', function () {
+          expect(stderr).to.include('ERROR: does-not-exist is not a valid path.')
+        })
+        // FIXME: we should exit early on v4
+        it('AND no ignore file is used, so errors are reported on the file', function () {
+          expect(stdout).to.include('1 problem')
+          expect(stdout).to.include('IgnoredDefault')
+        })
+        // FIXME: we should use a different error code for bad
+        // settings/parameters on v4
+        it('AND the program exits with error code 1', function () {
+          expect(code).to.eq(1)
+        })
+      })
+
+      describe('WHEN linting with --ignore-path pointing to a non-existent file AND that file does NOT have errors', function () {
+        beforeEach(function () {
+          ;({ code, stdout, stderr } = shell.exec(
+            'solhint --ignore-path does-not-exist NoErrors.sol',
+            {
+              silent: true,
+            }
+          ))
+        })
+        it('THEN an error is printed to stderr', function () {
+          expect(stderr).to.include('ERROR: does-not-exist is not a valid path.')
+        })
+        it('AND no errors are reported on stdout', function () {
+          expect(stdout.trim()).to.eq('')
+        })
+        // FIXME: I seriously do not agree with this. Change on v4
+        it('AND the program exits with error code 0', function () {
+          expect(code).to.eq(0)
+        })
+      })
+
+      // TODO: research what does eslint does with this and wether it's making
+      // it needlessly hard for editor integrations
+      describe('WHEN linting with the default .solhintignore AND passing an ignored file as a parameter', function () {
+        beforeEach(function () {
+          ;({ code, stdout } = shell.exec('solhint IgnoredDefault.sol', {
+            silent: true,
+          }))
+        })
+        it('THEN the file is ignored', function () {
+          expect(code).to.eq(0)
+          expect(stdout.trim()).to.equal('')
+        })
+      })
+
+      describe('WHEN linting with the default .solhintignore AND passing a glob for both files as a parameter', function () {
+        beforeEach(function () {
+          ;({ code, stdout } = shell.exec('solhint *.sol', {
+            silent: true,
+          }))
+        })
+
+        it('THEN IgnoreDefault is ignored', function () {
+          expect(stdout).not.to.contain('IgnoreDefault')
+        })
+
+        it('AND errors are reported on IgnoredOther', function () {
+          expect(code).to.eq(1)
+          expect(stdout).to.include('1 error')
+          expect(stdout).to.include('IgnoredOther')
+        })
+      })
+
+      describe('WHEN linting with a different ignore file AND passing a non-ignored file as a parameter', function () {
+        beforeEach(function () {
+          ;({ code, stdout } = shell.exec(
+            'solhint --ignore-path other-solhintignore IgnoredDefault.sol',
+            {
+              silent: true,
+            }
+          ))
+        })
+        it('THEN errors are reported on it', function () {
+          expect(code).to.eq(1)
+          expect(stdout).to.include('1 error')
+          expect(stdout).to.include('IgnoredDefault')
+        })
+      })
+
+      describe('WHEN linting with a different ignore file AND passing an ignored file as a parameter', function () {
+        beforeEach(function () {
+          ;({ code, stdout } = shell.exec(
+            'solhint --ignore-path other-solhintignore IgnoredOther.sol',
+            {
+              silent: true,
+            }
+          ))
+        })
+        it('THEN the file is ignored', function () {
+          expect(code).to.eq(0)
+          expect(stdout.trim()).to.equal('')
+        })
+      })
+
+      describe('WHEN linting with a different ignore file AND passing a glob for both files as a parameter', function () {
+        beforeEach(function () {
+          ;({ code, stdout } = shell.exec('solhint --ignore-path other-solhintignore *.sol', {
+            silent: true,
+          }))
+        })
+
+        it('THEN IgnoreOther is ignored', function () {
+          expect(stdout).not.to.contain('IgnoreOther')
+        })
+
+        it('AND errors are reported on IgnoredDefault', function () {
+          expect(code).to.eq(1)
+          expect(stdout).to.include('1 error')
+          expect(stdout).to.include('IgnoredDefault')
+        })
+      })
+    })
+  })
+
   describe('--max-warnings parameter tests', function () {
     useFixture('05-max-warnings')
     const warningExceededMsg = 'Solhint found more warnings than the maximum specified'
@@ -111,6 +284,21 @@ describe('main executable tests', function () {
         })
         it('AND it exits with error 1', function () {
           expect(code).to.equal(1)
+        })
+      })
+
+      describe('WHEN linting with --max-warnings 3 AND --quiet ', function () {
+        beforeEach(function () {
+          ;({ code, stdout } = shell.exec(
+            'solhint contracts/NoErrors6Warnings.sol --max-warnings 3 --quiet',
+            { silent: true }
+          ))
+        })
+        it('THEN reports 0 problems since all warnings are dropped', function () {
+          expect(stdout.trim()).to.eq('')
+        })
+        it('AND it exits with error 0', function () {
+          expect(code).to.equal(0)
         })
       })
     })


### PR DESCRIPTION
I don't think the behaviour of --ingore-file is consistent, I've created issue #80 to track this

- [x] --max-warnings and --quiet
- [x] --init tested already
- [x] --quiet
- [x] --formatter -- has their own suite
- [x] --config: coupled with --quiet. Not ideal but idc that much
- [x] --ignore-path
- [x] --fix -- covered by e2e/fixers.js

closes #77 
closes #66 