### PR TITLE
include interface-starts-with-i from defi wonderland's plugin

### DIFF
--- a/conf/rulesets/solhint-all.js
+++ b/conf/rulesets/solhint-all.js
@@ -9,6 +9,7 @@ module.exports = Object.freeze({
     'custom-errors': 'error',
     'explicit-types': ['warn'],
     'function-max-lines': ['warn', 50],
+    'interface-starts-with-i': 'error',
     'max-line-length': ['error', 120],
     'max-states-count': ['warn', 15],
     'no-console': 'error',

--- a/conf/rulesets/solhint-recommended.js
+++ b/conf/rulesets/solhint-recommended.js
@@ -7,6 +7,7 @@ module.exports = Object.freeze({
   rules: {
     'custom-errors': 'error',
     'explicit-types': ['warn'],
+    'interface-starts-with-i': 'error',
     'max-states-count': ['warn', 15],
     'no-console': 'error',
     'no-empty-blocks': 'warn',

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -26,17 +26,11 @@ title:       "Rule Index of Solhint"
 | [named-parameters-function](./rules/naming/named-parameters-function.md) | Enforce using named parameters when invoking a function with more than N arguments                                                         |             |
         
 
-## Miscellaneous
-
-| Rule Id                                                                     | Error                                                                                                                                  | Recommended |
-| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
-| [comprehensive-interface](./rules/miscellaneous/comprehensive-interface.md) | Check that all public or external functions are override. This is iseful to make sure that the whole API is extracted in an interface. |             |
-        
-
 ## Style Guide Rules
 
 | Rule Id                                                                              | Error                                                                                  | Recommended |
 | ------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | ----------- |
+| [interface-starts-with-i](./rules/naming/interface-starts-with-i.md)                 | Interfaces name should start with `I`                                                  | ✔️          |
 | [quotes](./rules/miscellaneous/quotes.md)                                            | Use double quotes for string literals. Values must be 'single' or 'double'.            | ✔️          |
 | [const-name-snakecase](./rules/naming/const-name-snakecase.md)                       | Constant name must be in capitalized SNAKE_CASE.                                       | ✔️          |
 | [contract-name-camelcase](./rules/naming/contract-name-camelcase.md)                 | Contract name must be in CamelCase.                                                    | ✔️          |
@@ -54,6 +48,13 @@ title:       "Rule Index of Solhint"
 | [imports-on-top](./rules/order/imports-on-top.md)                                    | Import statements must be on top.                                                      | ✔️          |
 | [ordering](./rules/order/ordering.md)                                                | Check order of elements in file and inside each contract, according to the style guide |             |
 | [visibility-modifier-order](./rules/order/visibility-modifier-order.md)              | Visibility modifier must be first in list of modifiers.                                | ✔️          |
+        
+
+## Miscellaneous
+
+| Rule Id                                                                     | Error                                                                                                                                  | Recommended |
+| --------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| [comprehensive-interface](./rules/miscellaneous/comprehensive-interface.md) | Check that all public or external functions are override. This is iseful to make sure that the whole API is extracted in an interface. |             |
         
 
 ## Security Rules

--- a/docs/rules/naming/interface-starts-with-i.md
+++ b/docs/rules/naming/interface-starts-with-i.md
@@ -1,0 +1,53 @@
+---
+warning:     "This is a dynamically generated file. Do not edit manually."
+layout:      "default"
+title:       "interface-starts-with-i | Solhint"
+---
+
+# interface-starts-with-i
+![Recommended Badge](https://img.shields.io/badge/-Recommended-brightgreen)
+![Category Badge](https://img.shields.io/badge/-Style%20Guide%20Rules-informational)
+![Default Severity Badge error](https://img.shields.io/badge/Default%20Severity-error-red)
+> The {"extends": "solhint:recommended"} property in a configuration file enables this rule.
+
+
+## Description
+Interfaces name should start with `I`
+
+## Options
+This rule accepts a string option of rule severity. Must be one of "error", "warn", "off". Default to error.
+
+### Example Config
+```json
+{
+  "rules": {
+    "interface-starts-with-i": "error"
+  }
+}
+```
+
+
+## Examples
+### 👍 Examples of **correct** code for this rule
+
+#### Interface name starts with I
+
+```solidity
+interface IFoo { function foo () external; }
+```
+
+### 👎 Examples of **incorrect** code for this rule
+
+#### Interface name doesnt start with I
+
+```solidity
+interface Foo { function foo () external; }
+```
+
+## Version
+This rule is introduced in the latest version.
+
+## Resources
+- [Rule source](https://github.com/solhint-community/solhint-community/tree/master/lib/rules/best-practises/interface-starts-with-i.js)
+- [Document source](https://github.com/solhint-community/solhint-community/tree/master/docs/rules/best-practises/interface-starts-with-i.md)
+- [Test cases](https://github.com/solhint-community/solhint-community/tree/master/test/rules/best-practises/interface-starts-with-i.js)

--- a/lib/rules/best-practises/index.js
+++ b/lib/rules/best-practises/index.js
@@ -1,4 +1,5 @@
 const CodeComplexityChecker = require('./code-complexity')
+const InterfaceStartsWithIChecker = require('./interface-starts-with-i')
 const FunctionMaxLinesChecker = require('./function-max-lines')
 const MaxLineLengthChecker = require('./max-line-length')
 const MaxStatesCountChecker = require('./max-states-count')
@@ -16,6 +17,7 @@ const OneContractPerFileChecker = require('./one-contract-per-file')
 module.exports = function checkers(reporter, config, inputSrc, tokens) {
   return [
     new CodeComplexityChecker(reporter, config),
+    new InterfaceStartsWithIChecker(reporter),
     new FunctionMaxLinesChecker(reporter, config),
     new MaxLineLengthChecker(reporter, config, inputSrc),
     new MaxStatesCountChecker(reporter, config),

--- a/lib/rules/best-practises/interface-starts-with-i.js
+++ b/lib/rules/best-practises/interface-starts-with-i.js
@@ -1,0 +1,45 @@
+const BaseChecker = require('../base-checker')
+
+const ruleId = 'interface-starts-with-i'
+const meta = {
+  type: 'naming',
+  docs: {
+    description: 'Interfaces name should start with `I`',
+    category: 'Style Guide Rules',
+    examples: {
+      good: [
+        {
+          description: 'Interface name starts with I',
+          code: `interface IFoo { function foo () external; }`,
+        },
+      ],
+      bad: [
+        {
+          description: 'Interface name doesnt start with I',
+          code: `interface Foo { function foo () external; }`,
+        },
+      ],
+    },
+  },
+  isDefault: true,
+  recommended: true,
+  defaultSetup: 'error',
+  schema: [],
+}
+
+class InterfaceStartsWithIChecker extends BaseChecker {
+  constructor(reporter) {
+    super(reporter, ruleId, meta)
+  }
+
+  ContractDefinition(node) {
+    if (node.kind !== 'interface') return
+    const interfaceName = node.name
+
+    if (!interfaceName.startsWith('I')) {
+      this.error(node, `Interface name '${interfaceName}' must start with "I"`)
+    }
+  }
+}
+
+module.exports = InterfaceStartsWithIChecker

--- a/test/rules/best-practises/interface-starts-with-i.js
+++ b/test/rules/best-practises/interface-starts-with-i.js
@@ -1,0 +1,34 @@
+const assert = require('assert')
+const { processStr } = require('../../../lib/index')
+const { configGetter } = require('../../../lib/config/config-file')
+
+const config = {
+  rules: { 'interface-starts-with-i': 'error' },
+}
+
+describe('Linter - interface-starts-with-i', () => {
+  it('should raise error for interface not starting with I', () => {
+    const code = 'interface Foo {}'
+    const report = processStr(code, config)
+
+    assert.equal(report.errorCount, 1)
+    assert.ok(report.messages[0].message === `Interface name 'Foo' must start with "I"`)
+  })
+
+  it('should be included in recommended config', () => {
+    const code = 'interface Foo {function Foo() external;}'
+    const report = processStr(code, {
+      rules: { ...configGetter('solhint:recommended').rules, 'compiler-version': 'off' },
+    })
+
+    assert.equal(report.errorCount, 1)
+    assert.ok(report.messages[0].message === `Interface name 'Foo' must start with "I"`)
+  })
+
+  it('should not raise error for interface starting with I', () => {
+    const code = 'interface IFoo {}'
+    const report = processStr(code, config)
+
+    assert.equal(report.errorCount, 0)
+  })
+})


### PR DESCRIPTION
this was actually implemented by @0xgorilla and @0xraccoon over at https://github.com/defi-wonderland/solhint-plugin and I think it's a worthy addition to mainline solhint ✨