### PR TITLE
named-return-values: ignore functions with return arity 1 by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@
 ### Updated
 - fully removed code for solhint:default ruleset https://github.com/solhint-community/solhint-community/pull/105
 
+### Added
+- added a config parameter to `named-return-values` to ignore functions with
+  less than N return values, and set the default to 1, to make it a less
+  disruptive addition to the recommended ruleset
+  https://github.com/solhint-community/solhint-community/pull/128
+
 ### Fixed
 - recognize shadowing of imports and stack variables https://github.com/solhint-community/solhint-community/pull/22
 - `plugins` field was being silently dropped from configs in last release

--- a/conf/rulesets/solhint-all.js
+++ b/conf/rulesets/solhint-all.js
@@ -35,7 +35,7 @@ module.exports = Object.freeze({
     'modifier-name-mixedcase': 'warn',
     'named-parameters-function': ['warn', 3],
     'named-parameters-mapping': 'warn',
-    'named-return-values': 'warn',
+    'named-return-values': ['warn', 1],
     'private-vars-leading-underscore': [
       'warn',
       {

--- a/conf/rulesets/solhint-recommended.js
+++ b/conf/rulesets/solhint-recommended.js
@@ -26,7 +26,7 @@ module.exports = Object.freeze({
     'definition-name-capwords': 'error',
     'func-name-mixedcase': 'warn',
     'modifier-name-mixedcase': 'warn',
-    'named-return-values': 'warn',
+    'named-return-values': ['warn', 1],
     'use-forbidden-name': 'warn',
     'var-name-mixedcase': 'warn',
     'imports-on-top': 'warn',

--- a/docs/rules/naming/named-return-values.md
+++ b/docs/rules/naming/named-return-values.md
@@ -15,13 +15,19 @@ title:       "named-return-values | Solhint"
 Ensure function return parameters are named
 
 ## Options
-This rule accepts a string option of rule severity. Must be one of "error", "warn", "off". Default to warn.
+This rule accepts an array of options:
+
+| Index | Description                                                                                                             | Default Value |
+| ----- | ----------------------------------------------------------------------------------------------------------------------- | ------------- |
+| 0     | Rule severity. Must be one of "error", "warn", "off".                                                                   | warn          |
+| 1     | An integer specifying the max amount of return values a function can have while still allowing them to remain anonymous | 1             |
+
 
 ### Example Config
 ```json
 {
   "rules": {
-    "named-return-values": "warn"
+    "named-return-values": ["warn",1]
   }
 }
 ```

--- a/lib/rules/naming/index.js
+++ b/lib/rules/naming/index.js
@@ -24,6 +24,6 @@ module.exports = function checkers(reporter, config) {
     new NamedParametersMappingChecker(reporter),
     new ImmutableNameSnakeCaseChecker(reporter),
     new FoundryTestFunctionsChecker(reporter, config),
-    new NamedReturnValuesChecker(reporter),
+    new NamedReturnValuesChecker(reporter, config),
   ]
 }

--- a/lib/rules/naming/named-return-values.js
+++ b/lib/rules/naming/named-return-values.js
@@ -2,6 +2,7 @@ const BaseChecker = require('../base-checker')
 const { severityDescription } = require('../../doc/utils')
 
 const DEFAULT_SEVERITY = 'warn'
+const DEFAULT_MAX_UNNAMED = 1
 
 const ruleId = 'named-return-values'
 const meta = {
@@ -14,6 +15,11 @@ const meta = {
       {
         description: severityDescription,
         default: DEFAULT_SEVERITY,
+      },
+      {
+        description:
+          'An integer specifying the max amount of return values a function can have while still allowing them to remain anonymous',
+        default: JSON.stringify(DEFAULT_MAX_UNNAMED),
       },
     ],
     examples: {
@@ -33,18 +39,21 @@ const meta = {
   },
 
   recommended: true,
-  defaultSetup: DEFAULT_SEVERITY,
+  defaultSetup: [DEFAULT_SEVERITY, DEFAULT_MAX_UNNAMED],
 
-  schema: null,
+  schema: { type: 'integer', minimum: 0 },
 }
 
 class NamedReturnValuesChecker extends BaseChecker {
-  constructor(reporter) {
+  constructor(reporter, config) {
     super(reporter, ruleId, meta)
+    this.maxAnonymousReturnValues = config
+      ? config.getNumber(ruleId, DEFAULT_MAX_UNNAMED)
+      : DEFAULT_MAX_UNNAMED
   }
 
   FunctionDefinition(node) {
-    if (node.returnParameters) {
+    if (node.returnParameters?.length > this.maxAnonymousReturnValues) {
       let index = 0
       for (const returnValue of node.returnParameters) {
         let ordinal = `${index + 1}-th`


### PR DESCRIPTION
and make it overrideable in the config
closes #116 
closes #89

is 'return arity' a thing btw?