### PR TITLE
running linter without a config file should use recommended config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## [4.0.0-rc02] - XXXX-XX-XX
 
 ### Breaking
+- use solhint:recommended when no config is available, instead of exiting with
+  an error https://github.com/solhint-community/solhint-community/pull/135
 - exit with a different code when linter is configured incorrectly (255) vs
   when errors are found in linted files (1) https://github.com/solhint-community/solhint-community/pull/134
     - also exit eagerly when a misconfiguration is detected, to help the programmer

--- a/e2e/stdin.js
+++ b/e2e/stdin.js
@@ -160,9 +160,12 @@ describe('e2e: stdin subcommand', function () {
       useFixture('09-fixers')
       describe('WHEN linting a file AND passing a non-existent extra config via -c', function () {
         beforeEach(function () {
-          ;({ code, stderr, stdout } = shell.exec('solhint stdin -c nothere.json < throw-error.sol', {
-            silent: true,
-          }))
+          ;({ code, stderr, stdout } = shell.exec(
+            'solhint stdin -c nothere.json < throw-error.sol',
+            {
+              silent: true,
+            }
+          ))
         })
         it('THEN it returns error code 255 for bad options', function () {
           expect(code).to.equal(255)
@@ -170,8 +173,8 @@ describe('e2e: stdin subcommand', function () {
         it('AND no errors are reported on stdout', function () {
           expect(stdout.trim()).to.eq('')
         })
-        it('AND it prints an error to stderr to let the dev know no config was found', function () {
-          expect(stderr).to.include('Extra config file "nothere.json" couldnt be found')
+        it('AND it vomits a ConfigMissing exception', function () {
+          expect(stderr).to.include('ConfigMissingError')
         })
       })
 
@@ -208,7 +211,7 @@ describe('e2e: stdin subcommand', function () {
         })
         it('AND it prints a warning to stderr to let the dev know no config was found', function () {
           expect(stderr).to.include(
-            'No rule configuration provided for "stdin"! proceeding with solhint:recommended'
+            'No rule configuration provided for stdin! proceeding with solhint:recommended'
           )
         })
       })
@@ -225,8 +228,8 @@ describe('e2e: stdin subcommand', function () {
         it('AND no errors are reported on stdout', function () {
           expect(stdout.trim()).to.eq('')
         })
-        it('AND it prints an error to stderr to let the dev know no config was found', function () {
-          expect(stderr).to.include('Extra config file "nothere.json" couldnt be found')
+        it('AND it vomits a ConfigMissing exception', function () {
+          expect(stderr).to.include('ConfigMissingError')
         })
       })
     })

--- a/e2e/stdin.js
+++ b/e2e/stdin.js
@@ -5,11 +5,11 @@ const shell = require('shelljs')
 const { useFixture, getFixtureFileContentSync } = require('./utils')
 
 describe('e2e: stdin subcommand', function () {
-  useFixture('09-fixers')
   let code
   let stdout
   let stderr
   describe('WHEN passing init-config ', function () {
+    useFixture('09-fixers')
     let originalConfig
     beforeEach(function () {
       originalConfig = getFixtureFileContentSync('.solhint.json')
@@ -28,6 +28,7 @@ describe('e2e: stdin subcommand', function () {
   })
 
   describe('WHEN passing --ignore-path ', function () {
+    useFixture('09-fixers')
     beforeEach(function () {
       ;({ code, stdout, stderr } = shell.exec(
         'solhint stdin --ignore-path ignore-throw-error --filename throw-error.sol < throw-error.sol',
@@ -43,6 +44,7 @@ describe('e2e: stdin subcommand', function () {
   })
 
   describe('--quiet is respected', function () {
+    useFixture('09-fixers')
     describe('WHEN checking a file with one warning and one error AND using --quiet', function () {
       beforeEach(function () {
         ;({ code, stdout } = shell.exec(
@@ -62,6 +64,7 @@ describe('e2e: stdin subcommand', function () {
   })
 
   describe('--quiet drops warnings so --max-warnings has no effect', function () {
+    useFixture('09-fixers')
     describe('WHEN checking a file with one warning AND using --quiet AND using --max-warnings 0', function () {
       beforeEach(function () {
         ;({ code, stdout } = shell.exec(
@@ -83,6 +86,7 @@ describe('e2e: stdin subcommand', function () {
   })
 
   describe('--filename value is used for report ', () => {
+    useFixture('09-fixers')
     describe('WHEN running the linter on a file with an error on stdin', function () {
       beforeEach(function () {
         ;({ code, stdout } = shell.exec('solhint stdin < throw-error.sol', {
@@ -133,6 +137,7 @@ describe('e2e: stdin subcommand', function () {
   })
 
   describe('--formatter is used', () => {
+    useFixture('09-fixers')
     describe('WHEN running the linter on a file with an error on stdin AND choosing the unix formatter', function () {
       beforeEach(function () {
         ;({ code, stdout } = shell.exec('solhint stdin --formatter unix < throw-error.sol', {
@@ -151,24 +156,84 @@ describe('e2e: stdin subcommand', function () {
   })
 
   describe('--config is used', () => {
-    describe('WHEN running the linter on a file with an error on stdin AND a config file that disables the rule for said error', function () {
-      beforeEach(function () {
-        ;({ code, stdout } = shell.exec(
-          'solhint stdin --config disabled-rules.json < throw-error.sol',
-          { silent: true }
-        ))
+    describe('GIVEN a directory with a config', function () {
+      useFixture('09-fixers')
+      describe('WHEN linting a file AND passing a non-existent extra config via -c', function () {
+        beforeEach(function () {
+          ;({ code, stderr, stdout } = shell.exec('solhint stdin -c nothere.json < throw-error.sol', {
+            silent: true,
+          }))
+        })
+        it('THEN it returns error code 255 for bad options', function () {
+          expect(code).to.equal(255)
+        })
+        it('AND no errors are reported on stdout', function () {
+          expect(stdout.trim()).to.eq('')
+        })
+        it('AND it prints an error to stderr to let the dev know no config was found', function () {
+          expect(stderr).to.include('Extra config file "nothere.json" couldnt be found')
+        })
       })
 
-      it('THEN it exits with code 0', function () {
-        expect(code).to.eq(0)
+      describe('WHEN running the linter on a file with an error on stdin AND a config file that disables the rule for said error', function () {
+        beforeEach(function () {
+          ;({ code, stdout } = shell.exec(
+            'solhint stdin --config disabled-rules.json < throw-error.sol',
+            { silent: true }
+          ))
+        })
+
+        it('THEN it exits with code 0', function () {
+          expect(code).to.eq(0)
+        })
+        it('AND reports no errors', function () {
+          expect(stdout.trim()).to.eq('')
+        })
       })
-      it('AND reports no errors', function () {
-        expect(stdout.trim()).to.eq('')
+    })
+
+    describe('GIVEN a directory without a config', function () {
+      useFixture('01-no-config')
+      describe('WHEN linting a file via stdin', function () {
+        beforeEach(function () {
+          ;({ code, stderr, stdout } = shell.exec('solhint stdin < Foo.sol', { silent: true }))
+        })
+        it('THEN it returns error code 1 for found errors', function () {
+          expect(code).to.equal(1)
+        })
+        it('AND it reports errors on recommended rules', function () {
+          expect(stdout).to.include('compiler-version')
+          expect(stdout).to.include('no-empty-blocks')
+          expect(stdout).to.include('2 problems')
+        })
+        it('AND it prints a warning to stderr to let the dev know no config was found', function () {
+          expect(stderr).to.include(
+            'No rule configuration provided for "stdin"! proceeding with solhint:recommended'
+          )
+        })
+      })
+
+      describe('WHEN linting a file AND passing a non-existent extra config via -c', function () {
+        beforeEach(function () {
+          ;({ code, stderr, stdout } = shell.exec('solhint stdin -c nothere.json < Foo.sol', {
+            silent: true,
+          }))
+        })
+        it('THEN it returns error code 255 for bad options', function () {
+          expect(code).to.equal(255)
+        })
+        it('AND no errors are reported on stdout', function () {
+          expect(stdout.trim()).to.eq('')
+        })
+        it('AND it prints an error to stderr to let the dev know no config was found', function () {
+          expect(stderr).to.include('Extra config file "nothere.json" couldnt be found')
+        })
       })
     })
   })
 
   describe('--max-warnings is used', () => {
+    useFixture('09-fixers')
     describe('WHEN running the linter on a file with a warning', function () {
       beforeEach(function () {
         ;({ code, stdout } = shell.exec(
@@ -204,6 +269,7 @@ describe('e2e: stdin subcommand', function () {
   })
 
   describe('--fix triggers filter mode', () => {
+    useFixture('09-fixers')
     describe('WHEN running as a fixer on a stdin stream with only one fixable error', function () {
       beforeEach(function () {
         ;({ code, stdout } = shell.exec('solhint stdin --fix < throw-error.sol', { silent: true }))

--- a/e2e/test.js
+++ b/e2e/test.js
@@ -58,8 +58,8 @@ describe('main executable tests', function () {
       it('AND no errors are reported on stdout', function () {
         expect(stdout.trim()).to.eq('')
       })
-      it('AND it prints an error to stderr to let the dev know no config was found', function () {
-        expect(stderr).to.include('Extra config file "nothere.json" couldnt be found')
+      it('AND it vomits a ConfigMissing exception', function () {
+        expect(stderr).to.include('ConfigMissingError')
       })
     })
 
@@ -103,8 +103,8 @@ describe('main executable tests', function () {
       it('AND stdout is empty', function () {
         expect(stdout.trim()).to.eq('')
       })
-      it('AND stderr logs the file wasnt found', function () {
-        expect(stderr.trim()).to.include('Extra config file "nothere.json" couldnt be found')
+      it('AND it vomits a ConfigMissing exception', function () {
+        expect(stderr).to.include('ConfigMissingError')
       })
     })
     describe('GIVEN a config file with invalid syntax, WHEN linting', function () {
@@ -467,10 +467,8 @@ describe('main executable tests', function () {
         it('THEN it returns error code 255 for bad options', function () {
           expect(code).to.equal(255)
         })
-        it('AND stderr logs the file wasnt found', function () {
-          expect(stderr.trim()).to.include(
-            'Extra config file "config-file-with-weird-name.json" couldnt be found'
-          )
+        it('AND it vomits a ConfigMissing exception', function () {
+          expect(stderr).to.include('ConfigMissingError')
         })
         it('AND it does NOT list disabled rules', function () {
           expect(stdout).to.eq('')

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -129,6 +129,7 @@ const applyExtends = (config, getter = configGetter) => {
 }
 
 const loadFullConfigurationForPath = (filepath, extraConfig, root = process.cwd()) => {
+  let isFallback = false
   let config = listConfigsForPath(filepath, root)
     .map((configDirectory) => {
       try {
@@ -146,9 +147,10 @@ const loadFullConfigurationForPath = (filepath, extraConfig, root = process.cwd(
     config = mergeConfigs(config, loadConfig(extraConfig))
   }
   if (['rules', 'extends'].every((key) => Object.keys(config[key]).length === 0)) {
-    throw new ConfigMissingError()
+    isFallback = true
+    config = mergeConfigs(config, { ...emptyConfig(), extends: 'solhint:recommended' })
   }
-  return { filepath, config }
+  return { filepath, config, isFallback }
 }
 
 module.exports = {

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -145,7 +145,6 @@ const loadFullConfigurationForPath = (filepath, extraConfig, root = process.cwd(
     // there, we should crash and burn
     config = mergeConfigs(config, loadConfig(extraConfig))
   }
-  // this should change with #90
   if (['rules', 'extends'].every((key) => Object.keys(config[key]).length === 0)) {
     throw new ConfigMissingError()
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,8 +4,7 @@ const parser = require('@solidity-parser/parser')
 const glob = require('glob')
 const ignore = require('ignore')
 const astParents = require('ast-parents')
-const { applyExtends, loadFullConfigurationForPath, emptyConfig } = require('./config/config-file')
-const { ConfigMissingError } = require('./common/errors')
+const { applyExtends, loadFullConfigurationForPath } = require('./config/config-file')
 const applyFixes = require('./apply-fixes')
 const ruleFixer = require('./rule-fixer')
 const Reporter = require('./reporter')
@@ -69,19 +68,14 @@ function processFile(file, config) {
 function processPath(pathOrGlob, rootIgnore, extraConfigPath) {
   return glob
     .sync(pathOrGlob, { nodir: true })
-    .map((filepath) => {
-      try {
-        return loadFullConfigurationForPath(filepath, extraConfigPath)
-      } catch (e) {
-        if (e instanceof ConfigMissingError) {
-          console.error(
-            `No rule configuration provided for file "${filepath}"! proceeding with solhint:recommended`
-          )
-          return { filepath, config: { ...emptyConfig(), extends: 'solhint:recommended' } }
-        } else {
-          throw e
-        }
+    .map((it) => {
+      const { filepath, config, isFallback } = loadFullConfigurationForPath(it, extraConfigPath)
+      if (isFallback) {
+        console.error(
+          `No rule configuration provided for file "${filepath}"! proceeding with solhint:recommended`
+        )
       }
+      return { filepath, config }
     })
     .filter(({ filepath, config }) => {
       const ignoreFilter = ignore({ allowRelativePaths: true })

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,8 @@ const parser = require('@solidity-parser/parser')
 const glob = require('glob')
 const ignore = require('ignore')
 const astParents = require('ast-parents')
-const { applyExtends, loadFullConfigurationForPath } = require('./config/config-file')
+const { applyExtends, loadFullConfigurationForPath, emptyConfig } = require('./config/config-file')
+const { ConfigMissingError } = require('./common/errors')
 const applyFixes = require('./apply-fixes')
 const ruleFixer = require('./rule-fixer')
 const Reporter = require('./reporter')
@@ -68,7 +69,20 @@ function processFile(file, config) {
 function processPath(pathOrGlob, rootIgnore, extraConfigPath) {
   return glob
     .sync(pathOrGlob, { nodir: true })
-    .map((filepath) => loadFullConfigurationForPath(filepath, extraConfigPath))
+    .map((filepath) => {
+      try {
+        return loadFullConfigurationForPath(filepath, extraConfigPath)
+      } catch (e) {
+        if (e instanceof ConfigMissingError) {
+          console.error(
+            `No rule configuration provided for file "${filepath}"! proceeding with solhint:recommended`
+          )
+          return { filepath, config: { ...emptyConfig(), extends: 'solhint:recommended' } }
+        } else {
+          throw e
+        }
+      }
+    })
     .filter(({ filepath, config }) => {
       const ignoreFilter = ignore({ allowRelativePaths: true })
         .add(config.excludedFiles)

--- a/test/common/config-file.js
+++ b/test/common/config-file.js
@@ -65,6 +65,31 @@ describe('Config file', () => {
         },
       })
     })
+    it('when config is found at default location, isFallback returns false', function () {
+      const { isFallback } = loadFullConfigurationForPath(
+        './test/fixtures/config-file/06-subdirectory/sub/Foo.sol',
+        undefined,
+        './test/fixtures/config-file/06-subdirectory'
+      )
+      assert(!isFallback)
+    })
+    it('when config is found at default location AND at extra config path, isFallback returns false', function () {
+      const { isFallback } = loadFullConfigurationForPath(
+        './test/fixtures/config-file/06-subdirectory/sub/Foo.sol',
+        './test/fixtures/config-file/06-subdirectory/extra.json',
+        './test/fixtures/config-file/06-subdirectory'
+      )
+      assert(!isFallback)
+    })
+
+    it('when config is found only at extra config path, isFallback returns false', function () {
+      const { isFallback } = loadFullConfigurationForPath(
+        './test/fixtures/config-file/01-no-config/Foo.sol',
+        './test/fixtures/config-file/06-subdirectory/extra.json',
+        './test/fixtures/config-file/01-no-config'
+      )
+      assert(!isFallback)
+    })
     it('rule setting in subdirectory overrides root config', function () {
       const { config } = loadFullConfigurationForPath(
         './test/fixtures/config-file/06-subdirectory/sub/Foo.sol',
@@ -91,38 +116,47 @@ describe('Config file', () => {
         ConfigMissingError
       )
     })
-    it('empty config and no extraConfig causes an error', function () {
-      assert.throws(
-        () =>
-          loadFullConfigurationForPath(
-            './test/fixtures/config-file/07-no-rules-or-extends/Foo.sol',
-            undefined,
-            './test/fixtures/config-file/07-no-rules-or-extends'
-          ),
-        ConfigMissingError
+    it('empty config and no extraConfig returns solhint:recommended and isFallback: true', function () {
+      const { config, isFallback } = loadFullConfigurationForPath(
+        './test/fixtures/config-file/07-no-rules-or-extends/Foo.sol',
+        undefined,
+        './test/fixtures/config-file/07-no-rules-or-extends'
       )
+      assert(isFallback)
+      assert.deepStrictEqual(config, {
+        excludedFiles: [],
+        extends: ['solhint:recommended'],
+        plugins: [],
+        rules: {},
+      })
     })
-    it('no config causes an error', function () {
-      assert.throws(
-        () =>
-          loadFullConfigurationForPath(
-            './test/fixtures/config-file/01-no-config/Foo.sol',
-            undefined,
-            './test/fixtures/config-file/01-no-config'
-          ),
-        ConfigMissingError
+    it('no config returns solhint:recommended and isFallback: true', function () {
+      const { config, isFallback } = loadFullConfigurationForPath(
+        './test/fixtures/config-file/01-no-config/Foo.sol',
+        undefined,
+        './test/fixtures/config-file/01-no-config'
       )
+      assert(isFallback)
+      assert.deepStrictEqual(config, {
+        excludedFiles: [],
+        extends: ['solhint:recommended'],
+        plugins: [],
+        rules: {},
+      })
     })
-    it('config with only excludedFiles causes an error', function () {
-      assert.throws(
-        () =>
-          loadFullConfigurationForPath(
-            './test/fixtures/config-file/08-only-excludefiles/Foo.sol',
-            undefined,
-            './test/fixtures/config-file/08-only-excludefiles/'
-          ),
-        ConfigMissingError
+    it('config with only excludedFiles returns solhint:recommended and isFallback: true, but also preserves the excludedFiles field', function () {
+      const { config, isFallback } = loadFullConfigurationForPath(
+        './test/fixtures/config-file/08-only-excludefiles/Foo.sol',
+        undefined,
+        './test/fixtures/config-file/08-only-excludefiles/'
       )
+      assert(isFallback)
+      assert.deepStrictEqual(config, {
+        excludedFiles: ['Foo.sol'],
+        extends: ['solhint:recommended'],
+        plugins: [],
+        rules: {},
+      })
     })
     it('extends: in subdirectory overrides explicit rule setting in root config', function () {
       const { config } = loadFullConfigurationForPath(
@@ -145,16 +179,19 @@ describe('Config file', () => {
         InvalidConfigError
       )
     })
-    it('no config && empty extraConfig causes error', function () {
-      assert.throws(
-        () =>
-          loadFullConfigurationForPath(
-            './test/fixtures/config-file/01-no-config/Foo.sol',
-            './test/fixtures/config-file/07-no-rules-or-extends/.solhintrc',
-            './test/fixtures/config-file/01-no-config'
-          ),
-        ConfigMissingError
+    it('no config && empty extraConfig returns solhint:recommended and isFallback: true', function () {
+      const { config, isFallback } = loadFullConfigurationForPath(
+        './test/fixtures/config-file/01-no-config/Foo.sol',
+        './test/fixtures/config-file/07-no-rules-or-extends/.solhintrc',
+        './test/fixtures/config-file/01-no-config'
       )
+      assert(isFallback)
+      assert.deepStrictEqual(config, {
+        excludedFiles: [],
+        extends: ['solhint:recommended'],
+        plugins: [],
+        rules: {},
+      })
     })
   })
 


### PR DESCRIPTION
closes #90
merge after #134

- [x] print a warning on stderr
- [x] chug along with solhint:recommended config
- [x] stdin extra: crashes on inexistent file passed via -c
    - [x] with other configs
    - [x] without other configs
- [x] stdin extra: --filename can trigger using other config files!!  already tested on e2e/configs-in-subdirectories
- [x] stdin: uses recommended config and prints a warning
- [x] move logic into loadFullConfigurationForPath to remove duplication
