### PR TITLE
disabling custom errors for <0.8.4 backport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ### Breaking
 - removed `foundry-test-functions` to be re-added in `4.1.0`
-https://github.com/solhint-community/solhint-community/pull/139
+  https://github.com/solhint-community/solhint-community/pull/139
+- disabled `custom-errors` on files whose pragma directive doesn't allow
+  versions equal or greater than 0.8.4, where they were introduced
+  https://github.com/solhint-community/solhint-community/pull/142
 
 ## [4.0.0-rc02] - 2024-02-20
 

--- a/docs/rules/best-practises/custom-errors.md
+++ b/docs/rules/best-practises/custom-errors.md
@@ -26,6 +26,8 @@ This rule accepts a string option of rule severity. Must be one of "error", "war
 }
 ```
 
+### Notes
+- This rule is automatically disabled for files whose pragma directive disallows versions where custom errors are available
 
 ## Examples
 ### 👍 Examples of **correct** code for this rule

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -1,3 +1,4 @@
+const semver = require('semver')
 const BaseChecker = require('../base-checker')
 const { severityDescription } = require('../../doc/utils')
 
@@ -14,6 +15,11 @@ const meta = {
       {
         description: severityDescription,
         default: DEFAULT_SEVERITY,
+      },
+    ],
+    notes: [
+      {
+        note: 'This rule is automatically disabled for files whose pragma directive disallows versions where custom errors are available',
       },
     ],
     examples: {
@@ -53,9 +59,19 @@ const meta = {
 class CustomErrorsChecker extends BaseChecker {
   constructor(reporter) {
     super(reporter, ruleId, meta)
+    this.skip = false
+  }
+
+  PragmaDirective(node) {
+    if (node.name === 'solidity') {
+      if (!semver.intersects(node.value, '>=0.8.4')) {
+        this.skip = true
+      }
+    }
   }
 
   FunctionCall(node) {
+    if (this.skip) return
     let errorStr = ''
     if (node.expression.name === 'require') {
       errorStr = 'require'

--- a/test/common/contract-builder.js
+++ b/test/common/contract-builder.js
@@ -1,8 +1,8 @@
 const { times } = require('lodash')
 
-function contractWith(code) {
+function contractWith(code, version) {
   return `
-      pragma solidity 0.4.4;
+      pragma solidity ${version || '0.4.4'};
         
         
       contract A {
@@ -22,12 +22,15 @@ function libraryWith(code) {
     `
 }
 
-function funcWith(statements) {
-  return contractWith(`
+function funcWith(statements, version) {
+  return contractWith(
+    `
         function b() public {
           ${statements}
         }
-    `)
+    `,
+    version
+  )
 }
 
 function modifierWith(statements) {

--- a/test/rules/best-practises/custom-errors.js
+++ b/test/rules/best-practises/custom-errors.js
@@ -10,7 +10,7 @@ const { funcWith } = require('../../common/contract-builder')
 
 describe('Linter - custom-errors', () => {
   it('should raise error for revert()', () => {
-    const code = funcWith(`revert();`)
+    const code = funcWith(`revert();`, '0.8.5')
     const report = linter.processStr(code, {
       rules: { 'custom-errors': 'error' },
     })
@@ -20,7 +20,7 @@ describe('Linter - custom-errors', () => {
   })
 
   it('should raise error for revert([string])', () => {
-    const code = funcWith(`revert("Insufficent funds");`)
+    const code = funcWith(`revert("Insufficent funds");`, '0.8.5')
     const report = linter.processStr(code, {
       rules: { 'custom-errors': 'error' },
     })
@@ -30,7 +30,7 @@ describe('Linter - custom-errors', () => {
   })
 
   it('should NOT raise error for revert ErrorFunction()', () => {
-    const code = funcWith(`revert ErrorFunction();`)
+    const code = funcWith(`revert ErrorFunction();`, '0.8.5')
     const report = linter.processStr(code, {
       rules: { 'custom-errors': 'error' },
     })
@@ -40,7 +40,7 @@ describe('Linter - custom-errors', () => {
   })
 
   it('should NOT raise error for revert ErrorFunction() with arguments', () => {
-    const code = funcWith(`revert ErrorFunction({ msg: "Insufficent funds msg" });`)
+    const code = funcWith(`revert ErrorFunction({ msg: "Insufficent funds msg" });`, '0.8.5')
     const report = linter.processStr(code, {
       rules: { 'custom-errors': 'error' },
     })
@@ -50,9 +50,12 @@ describe('Linter - custom-errors', () => {
   })
 
   it('should raise error for require', () => {
-    const code = funcWith(`require(!has(role, account), "Roles: account already has role");
+    const code = funcWith(
+      `require(!has(role, account), "Roles: account already has role");
         role.bearer[account] = true;role.bearer[account] = true;
-    `)
+    `,
+      '0.8.5'
+    )
     const report = linter.processStr(code, {
       rules: { 'custom-errors': 'error' },
     })
@@ -62,9 +65,12 @@ describe('Linter - custom-errors', () => {
   })
 
   it('should NOT raise error for regular function call', () => {
-    const code = funcWith(`callOtherFunction();
+    const code = funcWith(
+      `callOtherFunction();
         role.bearer[account] = true;role.bearer[account] = true;
-    `)
+    `,
+      '0.8.5'
+    )
     const report = linter.processStr(code, {
       rules: { 'custom-errors': 'error' },
     })
@@ -73,10 +79,13 @@ describe('Linter - custom-errors', () => {
   })
 
   it('should be included in [recommended] config', () => {
-    const code = funcWith(`require(!has(role, account), "Roles: account already has role");
+    const code = funcWith(
+      `require(!has(role, account), "Roles: account already has role");
         revert("RevertMessage");
         revert CustomError();
-    `)
+    `,
+      '0.8.5'
+    )
     const report = linter.processStr(code, {
       rules: { ...configGetter('solhint:recommended').rules, 'compiler-version': 'off' },
     })

--- a/test/rules/security/check-send-result.js
+++ b/test/rules/security/check-send-result.js
@@ -65,7 +65,7 @@ describe('Linter - check-send-result', () => {
       rules: { 'check-send-result': 'error' },
     })
     assert.equal(report.errorCount, 0)
-    report = linter.processStr(funcWith('bool success;', 'success = x.send(1);'), {
+    report = linter.processStr(funcWith('bool success; success = x.send(1);'), {
       rules: { 'check-send-result': 'error' },
     })
     assert.equal(report.errorCount, 0)


### PR DESCRIPTION
this closes #141

backports work done on https://github.com/protofire/solhint/pull/555/ and https://github.com/protofire/solhint/issues/507 by @dbale-altoros 

and fix(notreally,onlyonthisrepo)es https://github.com/protofire/solhint/issues/570