### PR TITLE
payable-fallback semantic changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [4.0.0-rc04] - XXXX-XX-XX
+
+### Breaking
+- changed payable-fallback to not revert when fallback function is not payable
+  but there's a receive function:
+  https://github.com/solhint-community/solhint-community/pull/145
+
 ## [4.0.0-rc03] - 2024-03-27
 
 ### Breaking

--- a/docs/rules/best-practises/payable-fallback.md
+++ b/docs/rules/best-practises/payable-fallback.md
@@ -43,9 +43,23 @@ This rule accepts a string option of rule severity. Must be one of "error", "war
     
 ```
 
+#### Fallback is not payable, but theres a receive function
+
+```solidity
+
+      pragma solidity 0.4.4;
+        
+        
+      contract A {
+        function () public {}
+receive() public{}
+      }
+    
+```
+
 ### 👎 Examples of **incorrect** code for this rule
 
-#### Fallback is not payable
+#### Fallback is not payable and theres no receive function
 
 ```solidity
 

--- a/lib/rules/best-practises/payable-fallback.js
+++ b/lib/rules/best-practises/payable-fallback.js
@@ -39,12 +39,12 @@ class PayableFallbackChecker extends BaseChecker {
     super(reporter, ruleId, meta)
   }
 
-  FunctionDefinition(node) {
-    if (isFallbackFunction(node)) {
-      if (node.stateMutability !== 'payable') {
-        this.warn(node, 'When fallback is not payable you will not be able to receive ether')
-      }
-    }
+  ContractDefinition(node) {
+    if (node.subNodes.some((it) => it.isReceiveEther)) return
+    const fallback = node.subNodes.find((it) => it.isFallback)
+    if (!fallback) return
+    if (fallback.stateMutability !== 'payable')
+      this.warn(node, 'When fallback is not payable you will not be able to receive ether')
   }
 }
 

--- a/lib/rules/best-practises/payable-fallback.js
+++ b/lib/rules/best-practises/payable-fallback.js
@@ -1,5 +1,5 @@
 const BaseChecker = require('../base-checker')
-const { isFallbackFunction } = require('../../common/ast-types')
+const { contractWith, multiLine } = require('../../../test/common/contract-builder')
 
 const ruleId = 'payable-fallback'
 const meta = {
@@ -12,13 +12,17 @@ const meta = {
       good: [
         {
           description: 'Fallback is payable',
-          code: require('../../../test/fixtures/best-practises/fallback-payable'),
+          code: contractWith('function () public payable {}'),
+        },
+        {
+          description: 'Fallback is not payable, but theres a receive function',
+          code: contractWith(multiLine('function () public {}', 'receive() public{}')),
         },
       ],
       bad: [
         {
-          description: 'Fallback is not payable',
-          code: require('../../../test/fixtures/best-practises/fallback-not-payable'),
+          description: 'Fallback is not payable and theres no receive function',
+          code: contractWith('function () public {}'),
         },
       ],
     },

--- a/test/fixtures/best-practises/fallback-not-payable.js
+++ b/test/fixtures/best-practises/fallback-not-payable.js
@@ -1,3 +1,0 @@
-const { contractWith } = require('../../common/contract-builder')
-
-module.exports = contractWith('function () public {}')

--- a/test/fixtures/best-practises/fallback-payable.js
+++ b/test/fixtures/best-practises/fallback-payable.js
@@ -1,3 +1,0 @@
-const { contractWith } = require('../../common/contract-builder')
-
-module.exports = contractWith('function () public payable {}')

--- a/test/rules/best-practises/payable-fallback.js
+++ b/test/rules/best-practises/payable-fallback.js
@@ -1,36 +1,46 @@
 const { assertNoWarnings, assertErrorMessage, assertWarnsCount } = require('../../common/asserts')
 const linter = require('../../../lib/index')
-const { contractWith } = require('../../common/contract-builder')
+const { contractWith, multiLine } = require('../../common/contract-builder')
 
 describe('Linter - payable-fallback', () => {
   it('should raise warn when fallback is not payable', () => {
-    const code = require('../../fixtures/best-practises/fallback-not-payable')
-
+    const code = contractWith('fallback () public {}')
     const report = linter.processStr(code, {
       rules: { 'payable-fallback': 'warn' },
     })
-
     assertWarnsCount(report, 1)
     assertErrorMessage(report, 'payable')
   })
 
-  it('should not raise warn when fallback is payable', () => {
-    const code = require('../../fixtures/best-practises/fallback-payable')
-
+  it('should not raise warn when fallback is payable -- legacy grammar', () => {
+    const code = contractWith('function () public payable {}')
     const report = linter.processStr(code, {
       rules: { 'payable-fallback': 'warn' },
     })
-
     assertNoWarnings(report)
   })
 
-  it('should ignore non-fallback functions', () => {
-    const code = contractWith('function f() {} function g() payable {}')
-
+  it('should not raise warn when fallback is payable', () => {
+    const code = contractWith('fallback () public payable {}')
     const report = linter.processStr(code, {
       rules: { 'payable-fallback': 'warn' },
     })
+    assertNoWarnings(report)
+  })
 
+  it('should ignore contracts without fallback functions', () => {
+    const code = contractWith('function f() {} function g() payable {}')
+    const report = linter.processStr(code, {
+      rules: { 'payable-fallback': 'warn' },
+    })
+    assertNoWarnings(report)
+  })
+
+  it('should NOT warn when fallback is not payable AND there is a receive function', function () {
+    const code = contractWith(multiLine('function () public {}', 'receive() public{}'))
+    const report = linter.processStr(code, {
+      rules: { 'payable-fallback': 'warn' },
+    })
     assertNoWarnings(report)
   })
 })


### PR DESCRIPTION
I tried to add a case where a regular function is named `fallback` to document this rule won't take care of that, but both the compiler & LSP will warn on it, but currently the parser rejects said grammar. I should open an issue for that.

closes #140 