### PR TITLE
chore: update compiler-version to require the latest safe compiler version 

### DIFF
--- a/conf/rulesets/solhint-all.js
+++ b/conf/rulesets/solhint-all.js
@@ -64,7 +64,7 @@ module.exports = Object.freeze({
     'avoid-throw': 'warn',
     'avoid-tx-origin': 'warn',
     'check-send-result': 'warn',
-    'compiler-version': ['error', '^0.8.14'],
+    'compiler-version': ['error', '^0.8.23'],
     'func-visibility': [
       'warn',
       {

--- a/conf/rulesets/solhint-recommended.js
+++ b/conf/rulesets/solhint-recommended.js
@@ -49,7 +49,7 @@ module.exports = Object.freeze({
     'avoid-throw': 'warn',
     'avoid-tx-origin': 'warn',
     'check-send-result': 'warn',
-    'compiler-version': ['error', '^0.8.14'],
+    'compiler-version': ['error', '^0.8.23'],
     'func-visibility': [
       'warn',
       {

--- a/docs/rules/security/compiler-version.md
+++ b/docs/rules/security/compiler-version.md
@@ -18,9 +18,9 @@ Compiler version must satisfy a semver requirement.
 This rule accepts an array of options:
 
 | Index | Description                                           | Default Value |
-| ----- | ----------------------------------------------------- |---------------|
+| ----- | ----------------------------------------------------- | ------------- |
 | 0     | Rule severity. Must be one of "error", "warn", "off". | error         |
-| 1     | Semver requirement                                    | ^0.8.23       |
+| 1     | Semver requirement                                    | ^0.8.14       |
 
 
 ### Example Config

--- a/docs/rules/security/compiler-version.md
+++ b/docs/rules/security/compiler-version.md
@@ -20,7 +20,7 @@ This rule accepts an array of options:
 | Index | Description                                           | Default Value |
 | ----- | ----------------------------------------------------- | ------------- |
 | 0     | Rule severity. Must be one of "error", "warn", "off". | error         |
-| 1     | Semver requirement                                    | ^0.8.14       |
+| 1     | Semver requirement                                    | ^0.8.23       |
 
 
 ### Example Config

--- a/docs/rules/security/compiler-version.md
+++ b/docs/rules/security/compiler-version.md
@@ -18,16 +18,16 @@ Compiler version must satisfy a semver requirement.
 This rule accepts an array of options:
 
 | Index | Description                                           | Default Value |
-| ----- | ----------------------------------------------------- | ------------- |
+| ----- | ----------------------------------------------------- |---------------|
 | 0     | Rule severity. Must be one of "error", "warn", "off". | error         |
-| 1     | Semver requirement                                    | ^0.8.14       |
+| 1     | Semver requirement                                    | ^0.8.23       |
 
 
 ### Example Config
 ```json
 {
   "rules": {
-    "compiler-version": ["error","^0.8.14"]
+    "compiler-version": ["error","^0.8.23"]
   }
 }
 ```

--- a/lib/rules/security/compiler-version.js
+++ b/lib/rules/security/compiler-version.js
@@ -4,7 +4,7 @@ const { severityDescription } = require('../../doc/utils')
 
 const ruleId = 'compiler-version'
 const DEFAULT_SEVERITY = 'error'
-const DEFAULT_SEMVER = '^0.8.14'
+const DEFAULT_SEMVER = '^0.8.23'
 const meta = {
   type: 'security',
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "solhint-community",
-  "version": "4.0.0-rc02",
+  "version": "4.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "solhint-community",
-      "version": "4.0.0-rc02",
+      "version": "4.0.0",
       "license": "MIT",
       "dependencies": {
         "@solidity-parser/parser": "^0.16.0",

--- a/test/rules/best-practises/one-contract-per-file.js
+++ b/test/rules/best-practises/one-contract-per-file.js
@@ -24,7 +24,7 @@ describe('Linter - one-contract-per-file', () => {
   })
 
   it('should not raise error for zero contracts', () => {
-    const report = linter.processStr('pragma solidity ^0.8.23;', {
+    const report = linter.processStr('pragma solidity ^0.8.14;', {
       rules: { 'one-contract-per-file': 'error' },
     })
     assertNoErrors(report)

--- a/test/rules/best-practises/one-contract-per-file.js
+++ b/test/rules/best-practises/one-contract-per-file.js
@@ -24,7 +24,7 @@ describe('Linter - one-contract-per-file', () => {
   })
 
   it('should not raise error for zero contracts', () => {
-    const report = linter.processStr('pragma solidity ^0.8.14;', {
+    const report = linter.processStr('pragma solidity ^0.8.23;', {
       rules: { 'one-contract-per-file': 'error' },
     })
     assertNoErrors(report)

--- a/test/rules/security/compiler-version.js
+++ b/test/rules/security/compiler-version.js
@@ -211,8 +211,8 @@ describe('Linter - compiler-version', () => {
     assertNoErrors(report)
   })
 
-  it(`should report error with version 0.8.13 and no options`, () => {
-    const report = linter.processStr(`pragma solidity ^0.8.13;`, {
+  it(`should report error with version 0.8.22 and no options`, () => {
+    const report = linter.processStr(`pragma solidity ^0.8.22;`, {
       rules: { 'compiler-version': 'error' },
     })
 

--- a/test/rules/security/compiler-version.js
+++ b/test/rules/security/compiler-version.js
@@ -203,8 +203,8 @@ describe('Linter - compiler-version', () => {
     assert.equal(report.errorCount, 0)
   })
 
-  it(`should not report error with version 0.8.14 and no options`, () => {
-    const report = linter.processStr(`pragma solidity ^0.8.14;`, {
+  it(`should not report error with version 0.8.23 and no options`, () => {
+    const report = linter.processStr(`pragma solidity ^0.8.23;`, {
       rules: { 'compiler-version': 'error' },
     })
 


### PR DESCRIPTION
closes #154 

Updates all instances of outdated 0.8.14, unit tests passing
Updates package-lock.json to be in line with master