### PR TITLE
feat: exception on style-guide-casing for pure functions with upper snake case capitalization

### DIFF
--- a/lib/rules/naming/style-guide-casing.js
+++ b/lib/rules/naming/style-guide-casing.js
@@ -178,7 +178,14 @@ class StyleGuideCasingChecker extends BaseChecker {
   }
 
   FunctionDefinition(node) {
-    if (!isMixedCase(node.name) && !node.isConstructor) {
+    if (node.isConstructor) return
+
+    // Allow pure functions to be either mixedCase or UPPER_SNAKE_CASE
+    if (node.stateMutability === 'pure') {
+      if (!isMixedCase(node.name) && !isUpperSnakeCase(node.name)) {
+        this.errorIfNotIgnored(node, 'Pure function name must be in mixedCase or UPPER_SNAKE_CASE')
+      }
+    } else if (!isMixedCase(node.name)) {
       this.errorIfNotIgnored(node, 'Function name must be in mixedCase')
     }
   }

--- a/test/rules/naming/style-guide-casing.js
+++ b/test/rules/naming/style-guide-casing.js
@@ -226,6 +226,48 @@ describe('style-guide-casing', function () {
         })
       }
     })
+
+    it('should allow pure functions to be in UPPER_SNAKE_CASE', () => {
+      const code = contractWith('function FOO_BAR() public pure returns (uint256) {}')
+      const report = processStr(code, {
+        rules: { 'style-guide-casing': 'error' },
+      })
+      assert.equal(report.errorCount, 0)
+    })
+
+    it('should allow interface functions with same name as immutable to be in UPPER_SNAKE_CASE', () => {
+      const code = 'interface IFoo { function FOO_BAR() external pure returns (address); }'
+      const report = processStr(code, {
+        rules: { 'style-guide-casing': 'error' },
+      })
+      assert.equal(report.errorCount, 0)
+    })
+
+    it('should raise error for pure functions not in mixedCase or UPPER_SNAKE_CASE', () => {
+      const code = contractWith('function snake_case() public pure returns (uint256) {}')
+      const report = processStr(code, {
+        rules: { 'style-guide-casing': 'error' },
+      })
+      assert.equal(report.errorCount, 1)
+      assert.ok(
+        report.messages[0].message.includes(
+          'Pure function name must be in mixedCase or UPPER_SNAKE_CASE'
+        )
+      )
+    })
+
+    it('should raise error for pure interface functions not in mixedCase or UPPER_SNAKE_CASE', () => {
+      const code = 'interface IFoo { function snake_case() external pure returns (address); }'
+      const report = processStr(code, {
+        rules: { 'style-guide-casing': 'error' },
+      })
+      assert.equal(report.errorCount, 1)
+      assert.ok(
+        report.messages[0].message.includes(
+          'Pure function name must be in mixedCase or UPPER_SNAKE_CASE'
+        )
+      )
+    })
   })
 
   describe('modifier names should be in mixedCase', () => {

--- a/test/rules/naming/style-guide-casing.js
+++ b/test/rules/naming/style-guide-casing.js
@@ -479,4 +479,35 @@ describe('style-guide-casing', function () {
     assert.equal(report.warningCount, 1)
     assert.ok(report.messages[0].message.includes('CapWords'))
   })
+
+  describe('pure free functions', function () {
+    it('should NOT raise error if a pure free function is in UPPER_SNAKE_CASE', () => {
+      const code = `
+        function FOO_BAR() pure returns (uint256) {
+          return 42;
+        }
+      `
+      const report = processStr(code, {
+        rules: { 'style-guide-casing': 'error' },
+      })
+      assert.equal(report.errorCount, 0)
+    })
+
+    it('should raise error if a pure free function is in snake_case', () => {
+      const code = `
+        function snake_case() pure returns (uint256) {
+          return 42;
+        }
+      `
+      const report = processStr(code, {
+        rules: { 'style-guide-casing': 'error' },
+      })
+      assert.equal(report.errorCount, 1)
+      assert.ok(
+        report.messages[0].message.includes(
+          'Pure function name must be in mixedCase or UPPER_SNAKE_CASE'
+        )
+      )
+    })
+  })
 })


### PR DESCRIPTION
closes #155 

- Adds exception to ```style-guide-casing``` allowing functions to be capitalized in camelCase but when they are also pure it's valid to capitalize them in UPPER_SNAKE_CASE