### PR TITLE
fix: discern usage of custom errors inside require for custom-errors rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [4.0.1] - XXXX-XX-XX
 ### Fixed
-- `custom-errors`: Made the rule more fine-grained by:
-  - Allowing custom errors as the second argument of `require` statements (e.g., `require(cond, CustomError())`) 
+- `custom-errors`: Made the rule more fine-grained by
+  allowing custom errors as the second argument of `require` statements (e.g., `require(cond, CustomError())`) 
+  https://github.com/solhint-community/solhint-community/pull/163
 
 ### Fixed
 - false positive in no-unused-var when function parameters are only used only as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+### Fixed
+- `custom-errors`: Made the rule more fine-grained by:
+  - Allowing custom errors as the second argument of `require` statements (e.g., `require(cond, CustomError())`) 
+  - Still flagging non-custom-error second arguments (e.g., string literals, numbers, variables)
+  - Still flagging `require` statements with no second argument
+
 ## [4.0.0] - 2024-04-10
 Stable release.
 Current `latest` version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 ### Fixed
 - `custom-errors`: Made the rule more fine-grained by:
   - Allowing custom errors as the second argument of `require` statements (e.g., `require(cond, CustomError())`) 
-  - Still flagging non-custom-error second arguments (e.g., string literals, numbers, variables)
-  - Still flagging `require` statements with no second argument
 
 ### Fixed
 - false positive in no-unused-var when function parameters are only used only as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
-## [Unreleased]
+## [4.0.1] - XXXX-XX-XX
 ### Fixed
 - `custom-errors`: Made the rule more fine-grained by:
   - Allowing custom errors as the second argument of `require` statements (e.g., `require(cond, CustomError())`) 
   - Still flagging non-custom-error second arguments (e.g., string literals, numbers, variables)
   - Still flagging `require` statements with no second argument
-
-## [4.0.1] - XXXX-XX-XX
 
 ### Fixed
 - false positive in no-unused-var when function parameters are only used only as

--- a/docs/rules/best-practises/custom-errors.md
+++ b/docs/rules/best-practises/custom-errors.md
@@ -44,6 +44,12 @@ revert CustomErrorFunction();
 revert CustomErrorFunction({ msg: "Insufficient Balance" });
 ```
 
+#### Use of require with a custom error function
+
+```solidity
+require(cond, CustomError());
+```
+
 ### 👎 Examples of **incorrect** code for this rule
 
 #### Use of require statement

--- a/docs/rules/best-practises/custom-errors.md
+++ b/docs/rules/best-practises/custom-errors.md
@@ -79,12 +79,6 @@ revert("Insufficient Balance");
 require(condition, x > 5 ? "Too high" : "Too low");
 ```
 
-#### Incorrect custom error syntax that will fail compilation
-
-```solidity
-revert(CustomError());  // Use "revert CustomError();" instead
-```
-
 ## Version
 This rule was introduced in [Solhint 3.7.0-rc02](https://github.com/solhint-community/solhint-community/tree/v3.7.0-rc02)
 

--- a/docs/rules/best-practises/custom-errors.md
+++ b/docs/rules/best-practises/custom-errors.md
@@ -28,6 +28,7 @@ This rule accepts a string option of rule severity. Must be one of "error", "war
 
 ### Notes
 - This rule is automatically disabled for files whose pragma directive disallows versions where custom errors are available
+- The rule does not analyze revert calls within assembly blocks
 - Limitation: The rule accepts any function call as a custom error. It does not verify if the function is a valid custom error constructor.
 - Complex expressions are disallowed as the second argument to `require` to maintain clarity and ensure that a straightforward custom error is used. This avoids potential issues where the expression could resolve to a string or other unintended types.
 
@@ -76,6 +77,12 @@ revert("Insufficient Balance");
 
 ```solidity
 require(condition, x > 5 ? "Too high" : "Too low");
+```
+
+#### Incorrect custom error syntax that will fail compilation
+
+```solidity
+revert(CustomError());  // Use "revert CustomError();" instead
 ```
 
 ## Version

--- a/docs/rules/best-practises/custom-errors.md
+++ b/docs/rules/best-practises/custom-errors.md
@@ -28,6 +28,8 @@ This rule accepts a string option of rule severity. Must be one of "error", "war
 
 ### Notes
 - This rule is automatically disabled for files whose pragma directive disallows versions where custom errors are available
+- Limitation: The rule accepts any function call as a custom error. It does not verify if the function is a valid custom error constructor.
+- Complex expressions are disallowed as the second argument to `require` to maintain clarity and ensure that a straightforward custom error is used. This avoids potential issues where the expression could resolve to a string or other unintended types.
 
 ## Examples
 ### 👍 Examples of **correct** code for this rule

--- a/docs/rules/best-practises/custom-errors.md
+++ b/docs/rules/best-practises/custom-errors.md
@@ -52,7 +52,7 @@ require(cond, CustomError());
 
 ### 👎 Examples of **incorrect** code for this rule
 
-#### Use of require statement
+#### Use of require with a string message
 
 ```solidity
 require(userBalance >= availableAmount, "Insufficient Balance");
@@ -68,6 +68,12 @@ revert();
 
 ```solidity
 revert("Insufficient Balance");
+```
+
+#### Use of require with a complex expression instead of a custom error
+
+```solidity
+require(condition, x > 5 ? "Too high" : "Too low");
 ```
 
 ## Version

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -91,12 +91,8 @@ class CustomErrorsChecker extends BaseChecker {
         errorStr = 'require'
       } else {
         const secondArg = node.arguments[1]
-        if (secondArg.type === 'StringLiteral') {
-          // e.g. require(cond, "Error message");
-          errorStr = 'require'
-        } else if (secondArg.type !== 'FunctionCall') {
-          // e.g. require(cond, 42) or require(cond, someVar)
-          // Probably not a custom error, so still flag
+        if (secondArg.type === 'StringLiteral' || secondArg.type !== 'FunctionCall') {
+          // e.g. require(cond, "Error message"); or  require(cond, 42) or require(cond, someVar)
           errorStr = 'require'
         }
         // else if secondArg.type === 'FunctionCall':

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -106,7 +106,7 @@ class CustomErrorsChecker extends BaseChecker {
    * @returns {boolean} - True if the require statement should be flagged.
    */
   isRequireInvalid(node) {
-    return node.arguments.length < 2 || node.arguments[1].type !== 'FunctionCall';
+    return node.arguments.length < 2 || node.arguments[1].type !== 'FunctionCall'
   }
 }
 

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -22,6 +22,9 @@ const meta = {
         note: 'This rule is automatically disabled for files whose pragma directive disallows versions where custom errors are available',
       },
       {
+        note: 'The rule does not analyze revert calls within assembly blocks',
+      },
+      {
         note: 'Limitation: The rule accepts any function call as a custom error. It does not verify if the function is a valid custom error constructor.',
       },
       {
@@ -60,6 +63,10 @@ const meta = {
           description: 'Use of require with a complex expression instead of a custom error',
           code: 'require(condition, x > 5 ? "Too high" : "Too low");',
         },
+        {
+          description: 'Incorrect custom error syntax that will fail compilation',
+          code: 'revert(CustomError());  // Use "revert CustomError();" instead',
+        },
       ],
     },
   },
@@ -88,6 +95,10 @@ class CustomErrorsChecker extends BaseChecker {
     const exprName = node.expression.name
 
     if (exprName === 'revert') {
+      // If revert is used as a function call (incorrect syntax), skip it
+      // The compiler will catch this error
+      if (node.type === 'FunctionCall' && node.expression.type === 'FunctionCall') return
+
       if (node.arguments.length === 0) {
         this.error(node, 'Use custom errors instead of empty revert statements')
       } else if (node.arguments[0].type === 'StringLiteral') {

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -91,10 +91,6 @@ class CustomErrorsChecker extends BaseChecker {
     const exprName = node.expression.name
 
     if (exprName === 'revert') {
-      // If revert is used as a function call (incorrect syntax), skip it
-      // The compiler will catch this error
-      if (node.type === 'FunctionCall' && node.expression.type === 'FunctionCall') return
-
       if (node.arguments.length === 0) {
         this.error(node, 'Use custom errors instead of empty revert statements')
       } else if (node.arguments[0].type === 'StringLiteral') {

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -106,12 +106,7 @@ class CustomErrorsChecker extends BaseChecker {
    * @returns {boolean} - True if the require statement should be flagged.
    */
   isRequireInvalid(node) {
-    if (node.arguments.length < 2) {
-      return true
-    }
-
-    const secondArg = node.arguments[1]
-    return secondArg.type === 'StringLiteral' || secondArg.type !== 'FunctionCall'
+    return node.arguments.length < 2 || node.arguments[1].type !== 'FunctionCall';
   }
 }
 

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -39,7 +39,7 @@ const meta = {
       ],
       bad: [
         {
-          description: 'Use of require statement',
+          description: 'Use of require with a string message',
           code: 'require(userBalance >= availableAmount, "Insufficient Balance");',
         },
         {
@@ -49,6 +49,10 @@ const meta = {
         {
           description: 'Use of revert statement with message',
           code: 'revert("Insufficient Balance");',
+        },
+        {
+          description: 'Use of require with a complex expression instead of a custom error',
+          code: 'require(condition, x > 5 ? "Too high" : "Too low");',
         },
       ],
     },
@@ -78,35 +82,24 @@ class CustomErrorsChecker extends BaseChecker {
     const exprName = node.expression.name
 
     if (exprName === 'revert') {
-      if (this.isRevertInvalid(node)) {
-        this.error(node, 'Use Custom Errors instead of revert statements')
+      if (node.arguments.length === 0) {
+        this.error(node, 'Use custom errors instead of empty revert statements')
+      } else if (node.arguments[0].type === 'StringLiteral') {
+        this.error(node, 'Use custom errors instead of string messages in revert')
       }
       return
     }
 
     if (exprName === 'require') {
-      if (this.isRequireInvalid(node)) {
-        this.error(node, 'Use Custom Errors instead of require statements')
+      if (node.arguments.length < 2) {
+        this.error(node, 'Provide a custom error as the second argument to require')
+      } else if (node.arguments[1].type !== 'FunctionCall') {
+        this.error(
+          node,
+          'The second argument of require should be a custom error. Avoid using string literals or complex expressions'
+        )
       }
     }
-  }
-
-  /**
-   * Determines if a revert statement is invalid (i.e., uses a string or no arguments).
-   * @param {Object} node - The AST node representing the function call.
-   * @returns {boolean} - True if the revert statement should be flagged.
-   */
-  isRevertInvalid(node) {
-    return node.arguments.length === 0 || node.arguments[0].type === 'StringLiteral'
-  }
-
-  /**
-   * Determines if a require statement is invalid (i.e., lacks a custom error as the second argument).
-   * @param {Object} node - The AST node representing the function call.
-   * @returns {boolean} - True if the require statement should be flagged.
-   */
-  isRequireInvalid(node) {
-    return node.arguments.length < 2 || node.arguments[1].type !== 'FunctionCall'
   }
 }
 

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -72,14 +72,37 @@ class CustomErrorsChecker extends BaseChecker {
 
   FunctionCall(node) {
     if (this.skip) return
+
     let errorStr = ''
-    if (node.expression.name === 'require') {
-      errorStr = 'require'
-    } else if (
+
+    // Check revert statements
+    if (
       node.expression.name === 'revert' &&
       (node.arguments.length === 0 || node.arguments[0].type === 'StringLiteral')
     ) {
       errorStr = 'revert'
+    }
+
+    // Check require statements
+    else if (node.expression.name === 'require') {
+      // If no second argument or second argument is a string, flag it
+      if (node.arguments.length < 2) {
+        // No second argument
+        errorStr = 'require'
+      } else {
+        const secondArg = node.arguments[1]
+        if (secondArg.type === 'StringLiteral') {
+          // e.g. require(cond, "Error message");
+          errorStr = 'require'
+        } else if (secondArg.type !== 'FunctionCall') {
+          // e.g. require(cond, 42) or require(cond, someVar)
+          // Probably not a custom error, so still flag
+          errorStr = 'require'
+        }
+        // else if secondArg.type === 'FunctionCall':
+        // e.g. require(cond, MyCustomError())
+        // We skip, because it’s presumably a custom error
+      }
     }
 
     if (errorStr !== '') {

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -63,10 +63,6 @@ const meta = {
           description: 'Use of require with a complex expression instead of a custom error',
           code: 'require(condition, x > 5 ? "Too high" : "Too low");',
         },
-        {
-          description: 'Incorrect custom error syntax that will fail compilation',
-          code: 'revert(CustomError());  // Use "revert CustomError();" instead',
-        },
       ],
     },
   },

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -21,6 +21,12 @@ const meta = {
       {
         note: 'This rule is automatically disabled for files whose pragma directive disallows versions where custom errors are available',
       },
+      {
+        note: 'Limitation: The rule accepts any function call as a custom error. It does not verify if the function is a valid custom error constructor.',
+      },
+      {
+        note: 'Complex expressions are disallowed as the second argument to `require` to maintain clarity and ensure that a straightforward custom error is used. This avoids potential issues where the expression could resolve to a string or other unintended types.',
+      },
     ],
     examples: {
       good: [

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -32,6 +32,10 @@ const meta = {
           description: 'Use of Custom Errors with arguments',
           code: 'revert CustomErrorFunction({ msg: "Insufficient Balance" });',
         },
+        {
+          description: 'Use of require with a custom error function',
+          code: 'require(cond, CustomError());',
+        },
       ],
       bad: [
         {
@@ -63,46 +67,51 @@ class CustomErrorsChecker extends BaseChecker {
   }
 
   PragmaDirective(node) {
-    if (node.name === 'solidity') {
-      if (!semver.intersects(node.value, '>=0.8.4')) {
-        this.skip = true
-      }
+    if (node.name === 'solidity' && !semver.intersects(node.value, '>=0.8.4')) {
+      this.skip = true
     }
   }
 
   FunctionCall(node) {
     if (this.skip) return
 
-    let errorStr = ''
+    const exprName = node.expression.name
 
-    // Check revert statements
-    if (
-      node.expression.name === 'revert' &&
-      (node.arguments.length === 0 || node.arguments[0].type === 'StringLiteral')
-    ) {
-      errorStr = 'revert'
+    if (exprName === 'revert') {
+      if (this.isRevertInvalid(node)) {
+        this.error(node, 'Use Custom Errors instead of revert statements')
+      }
+      return
     }
 
-    // Check require statements
-    else if (node.expression.name === 'require') {
-      // If no second argument or second argument is a string, flag it
-      if (node.arguments.length < 2) {
-        // No second argument
-        errorStr = 'require'
-      } else {
-        const secondArg = node.arguments[1]
-        if (secondArg.type === 'StringLiteral' || secondArg.type !== 'FunctionCall') {
-          // e.g. require(cond, "Error message"); or  require(cond, 42) or require(cond, someVar)
-          errorStr = 'require'
-        }
-        // e.g. require(cond, MyCustomError())
-        // We skip, because it’s presumably a custom error
+    if (exprName === 'require') {
+      if (this.isRequireInvalid(node)) {
+        this.error(node, 'Use Custom Errors instead of require statements')
       }
     }
+  }
 
-    if (errorStr !== '') {
-      this.error(node, `Use Custom Errors instead of ${errorStr} statements`)
+  /**
+   * Determines if a revert statement is invalid (i.e., uses a string or no arguments).
+   * @param {Object} node - The AST node representing the function call.
+   * @returns {boolean} - True if the revert statement should be flagged.
+   */
+  isRevertInvalid(node) {
+    return node.arguments.length === 0 || node.arguments[0].type === 'StringLiteral'
+  }
+
+  /**
+   * Determines if a require statement is invalid (i.e., lacks a custom error as the second argument).
+   * @param {Object} node - The AST node representing the function call.
+   * @returns {boolean} - True if the require statement should be flagged.
+   */
+  isRequireInvalid(node) {
+    if (node.arguments.length < 2) {
+      return true
     }
+
+    const secondArg = node.arguments[1]
+    return secondArg.type === 'StringLiteral' || secondArg.type !== 'FunctionCall'
   }
 }
 

--- a/lib/rules/best-practises/custom-errors.js
+++ b/lib/rules/best-practises/custom-errors.js
@@ -95,7 +95,6 @@ class CustomErrorsChecker extends BaseChecker {
           // e.g. require(cond, "Error message"); or  require(cond, 42) or require(cond, someVar)
           errorStr = 'require'
         }
-        // else if secondArg.type === 'FunctionCall':
         // e.g. require(cond, MyCustomError())
         // We skip, because it’s presumably a custom error
       }

--- a/test/rules/best-practises/custom-errors.js
+++ b/test/rules/best-practises/custom-errors.js
@@ -235,4 +235,58 @@ describe('Linter - custom-errors', () => {
     assertErrorCount(report, 1)
     assertErrorMessage(report, 'Use Custom Errors instead of require statements')
   })
+
+  it('should NOT raise error for require with custom error constructor call with expressions', () => {
+    const code = `
+      pragma solidity 0.8.5;
+      contract A {
+        function test(uint x) external {
+          require(msg.sender != address(0), CustomError(x + 1));
+        }
+      }
+    `
+    const report = linter.processStr(code, {
+      rules: { 'custom-errors': 'error' },
+    })
+    assertNoWarnings(report)
+    assertNoErrors(report)
+  })
+
+  it('should raise error for require with complex non-error expression', () => {
+    const code = `
+      pragma solidity 0.8.5;
+      contract A {
+        function test(uint x) external {
+          require(msg.sender != address(0), x > 5 ? "Too high" : "Too low");
+        }
+      }
+    `
+    const report = linter.processStr(code, {
+      rules: { 'custom-errors': 'error' },
+    })
+    assertErrorCount(report, 1)
+    assertErrorMessage(report, 'Use Custom Errors instead of require statements')
+  })
+
+  it('should NOT raise error for require with custom error with complex arguments', () => {
+    const code = `
+      pragma solidity 0.8.5;
+      contract A {
+        function test(uint x, string memory reason) external {
+          require(
+            msg.sender != address(0), 
+            ComplexError({
+              code: x > 5 ? 1 : 2,
+              message: string.concat("Error: ", reason)
+            })
+          );
+        }
+      }
+    `
+    const report = linter.processStr(code, {
+      rules: { 'custom-errors': 'error' },
+    })
+    assertNoWarnings(report)
+    assertNoErrors(report)
+  })
 })

--- a/test/rules/best-practises/custom-errors.js
+++ b/test/rules/best-practises/custom-errors.js
@@ -16,7 +16,7 @@ describe('Linter - custom-errors', () => {
     })
 
     assertErrorCount(report, 1)
-    assertErrorMessage(report, 'Use Custom Errors instead of revert statement')
+    assertErrorMessage(report, 'Use Custom Errors instead of revert statements')
   })
 
   it('should raise error for revert([string])', () => {
@@ -26,7 +26,7 @@ describe('Linter - custom-errors', () => {
     })
 
     assertErrorCount(report, 1)
-    assertErrorMessage(report, 'Use Custom Errors instead of revert statement')
+    assertErrorMessage(report, 'Use Custom Errors instead of revert statements')
   })
 
   it('should NOT raise error for revert ErrorFunction()', () => {
@@ -61,7 +61,7 @@ describe('Linter - custom-errors', () => {
     })
 
     assertErrorCount(report, 1)
-    assertErrorMessage(report, 'Use Custom Errors instead of require statement')
+    assertErrorMessage(report, 'Use Custom Errors instead of require statements')
   })
 
   it('should NOT raise error for regular function call', () => {
@@ -109,7 +109,7 @@ describe('Linter - custom-errors', () => {
       })
 
       assertErrorCount(report, 1)
-      assertErrorMessage(report, 'Use Custom Errors instead of revert statement')
+      assertErrorMessage(report, 'Use Custom Errors instead of revert statements')
     })
 
     it('should NOT emit error on exact match pragma directive for a previous version', function () {
@@ -141,7 +141,7 @@ describe('Linter - custom-errors', () => {
       })
 
       assertErrorCount(report, 1)
-      assertErrorMessage(report, 'Use Custom Errors instead of revert statement')
+      assertErrorMessage(report, 'Use Custom Errors instead of revert statements')
 
       code = `
         pragma solidity >=0.8.19 <0.9.0;
@@ -156,7 +156,7 @@ describe('Linter - custom-errors', () => {
       })
 
       assertErrorCount(report, 1)
-      assertErrorMessage(report, 'Use Custom Errors instead of revert statement')
+      assertErrorMessage(report, 'Use Custom Errors instead of revert statements')
     })
 
     it('should NOT emit error on range match disallowing 0.8.4 or later', function () {

--- a/test/rules/best-practises/custom-errors.js
+++ b/test/rules/best-practises/custom-errors.js
@@ -186,4 +186,53 @@ describe('Linter - custom-errors', () => {
       assertErrorCount(report, 0)
     })
   })
+
+  it('should NOT raise error for require with custom error function call as second argument', () => {
+    const code = `
+      pragma solidity 0.8.5;
+      contract A {
+        function test() external {
+          require(msg.sender != address(0), ZeroAddressError());
+        }
+      }
+    `
+    const report = linter.processStr(code, {
+      rules: { 'custom-errors': 'error' },
+    })
+    assertNoWarnings(report)
+    assertNoErrors(report)
+  })
+
+  it('should raise error for require with a non-function-call second argument', () => {
+    // second arg is a numeric literal instead of a function call
+    const code = `
+      pragma solidity 0.8.5;
+      contract A {
+        function test() external {
+          require(msg.sender != address(0), 123);
+        }
+      }
+    `
+    const report = linter.processStr(code, {
+      rules: { 'custom-errors': 'error' },
+    })
+    assertErrorCount(report, 1)
+    assertErrorMessage(report, 'Use Custom Errors instead of require statements')
+  })
+
+  it('should raise error for require with no second argument', () => {
+    const code = `
+      pragma solidity 0.8.5;
+      contract A {
+        function test() external {
+          require(msg.sender != address(0));
+        }
+      }
+    `
+    const report = linter.processStr(code, {
+      rules: { 'custom-errors': 'error' },
+    })
+    assertErrorCount(report, 1)
+    assertErrorMessage(report, 'Use Custom Errors instead of require statements')
+  })
 })


### PR DESCRIPTION
closes #148 

- Checks inside require statements to ensure more fine-grained linting now that custom errors inside require are supported