### PR TITLE
feat: add scope information to the ast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [4.1.0] - XXXX-XX-XX
+
+### Added
+- introduced `scope-manager.js` to handle lexical scoping and variable tracking prior to rule execution
+  https://github.com/solåhint-community/solhint-community/pull/167
+
+### Changed
+- simplified `no-unused-vars.js` to not modify the AST directly, having it rely on the logic from `scope-manager.js` instead
+  https://github.com/solåhint-community/solhint-community/pull/167
+
 ## [4.0.1] - XXXX-XX-XX
 
 ### Fixed

--- a/lib/common/scope-manager.js
+++ b/lib/common/scope-manager.js
@@ -1,4 +1,3 @@
-const _ = require('lodash')
 const parser = require('@solidity-parser/parser')
 
 const { visit } = parser
@@ -138,7 +137,6 @@ function attachScopes(ast) {
     },
 
     VariableDeclaration(node) {
-      if (!node.name) return
       const scope = scopeManager.getScope(node)
       if (scope) {
         scope.addVariable(node, node.name)
@@ -150,12 +148,11 @@ function attachScopes(ast) {
       if (isPartOfDeclaration(node)) return
 
       const name = node.name
-      if (!name) return
 
       // Track usage up the scope chain
       let scope = scopeManager.getScope(node)
       while (scope) {
-        if (scope.hasVariable(name) && scope.trackUsage(name)) {
+        if (scope.trackUsage(name)) {
           break
         }
         scope = scope.node.parent ? scopeManager.getScope(scope.node.parent) : null

--- a/lib/common/scope-manager.js
+++ b/lib/common/scope-manager.js
@@ -263,8 +263,17 @@ function attachScopes(ast) {
 
         if (n.type === 'AssemblyLocalDefinition') {
           // Track expression (right side) of assembly let statements
-          if (n.expression && n.expression.type === 'Identifier') {
-            trackIdentifierUsage(n.expression)
+        } else if (n.type === 'AssemblyAssignment') {
+          // Track both sides of assignments
+          visit(n.names)
+          visit(n.expression)
+        } else if (n.type === 'AssemblyCall') {
+          // Track function name and arguments
+          if (n.functionName) {
+            trackIdentifierUsage({ type: 'Identifier', name: n.functionName })
+          }
+          if (n.arguments) {
+            n.arguments.forEach(visit)
           }
         } else if (n.type === 'Identifier') {
           trackIdentifierUsage(n)
@@ -297,17 +306,20 @@ function attachScopes(ast) {
       if (!sourceScope) return
 
       // Handle unit alias (import "..." as A)
-      if (node.unitAliasIdentifier) {
+      if (node.unitAliasIdentifier?.name) {
         sourceScope.addVariable(node.unitAliasIdentifier, node.unitAliasIdentifier.name)
       } else if (node.unitAlias) {
         sourceScope.addVariable(node, node.unitAlias)
       }
 
       // Handle symbol aliases (import {A as B} from "...")
-      if (node.symbolAliasesIdentifiers) {
+      if (Array.isArray(node.symbolAliasesIdentifiers)) {
         for (const [origId, aliasId] of node.symbolAliasesIdentifiers) {
+          if (!origId) continue
           const realId = aliasId || origId
-          sourceScope.addVariable(realId, realId.name)
+          if (realId?.name) {
+            sourceScope.addVariable(realId, realId.name)
+          }
         }
       }
     },
@@ -389,11 +401,9 @@ function attachScopes(ast) {
       if (node.functions) {
         for (const fnStr of node.functions) {
           const first = fnStr.split('.')[0]
-          let cur = scope
+          const cur = scope
           while (cur) {
             if (cur.trackUsage(first)) break
-            const p = cur.node?.parent
-            cur = p ? scopeManager.getScope(p) : null
           }
         }
       }

--- a/lib/common/scope-manager.js
+++ b/lib/common/scope-manager.js
@@ -4,7 +4,9 @@ const { visit } = parser
 
 /**
  * Manages lexical scoping for a Solidity AST
- * Used to track variable declarations and their usage across different scopes
+ * Used to track variable declarations and their usage across different scopes.
+ * Each scope (source unit, contract, function, block) maintains its own set of variables
+ * and their usage counts.
  */
 class ScopeManager {
   constructor() {
@@ -31,6 +33,11 @@ class ScopeManager {
     return this.scopes.get(this.findScopeNode(node))
   }
 
+  /**
+   * Traverses up the AST to find the nearest ancestor node that has a scope
+   * @param {ASTNode} node - Starting node to search from
+   * @returns {ASTNode|undefined} The nearest ancestor with a scope, or undefined if none exists
+   */
   findScopeNode(node) {
     let current = node
     while (current && !this.scopes.has(current)) {
@@ -41,8 +48,8 @@ class ScopeManager {
 }
 
 /**
- * Represents a single lexical scope in the code
- * Tracks variables declared in this scope and their usage
+ * Represents a single lexical scope in the code.
+ * Tracks variables declared in this scope and how many times they are used.
  */
 class Scope {
   constructor(node) {
@@ -54,8 +61,15 @@ class Scope {
    * Adds a variable declaration to this scope
    * @param {ASTNode} node - The AST node representing the variable declaration
    * @param {string} name - The name of the variable
+   * @param {Object} opts - Options object
+   * @param {boolean} opts.ignore - If true, variable will be tracked but ignored in unused checks
    */
-  addVariable(node, name) {
+  addVariable(node, name, opts = {}) {
+    if (!name) return
+    // Special case: skip 'payable' as it can be both a type and parameter name
+    if (name === 'payable') return
+    if (opts.ignore) return
+
     if (!this.variables.has(name)) {
       this.variables.set(name, { node, usages: 0 })
     }
@@ -67,18 +81,18 @@ class Scope {
    * @returns {boolean} Whether the variable exists in this scope
    */
   trackUsage(name) {
-    const variable = this.variables.get(name)
-    if (variable) {
-      variable.usages++
+    const v = this.variables.get(name)
+    if (v) {
+      v.usages++
       return true
     }
     return false
   }
 
-  hasVariable(name) {
-    return this.variables.has(name)
-  }
-
+  /**
+   * Returns all variables in this scope that were never used
+   * @returns {Array<{name: string, node: ASTNode}>} Array of unused variables
+   */
   getUnusedVariables() {
     return Array.from(this.variables.entries())
       .filter(([, info]) => info.usages === 0)
@@ -87,17 +101,110 @@ class Scope {
 }
 
 /**
- * Analyzes an AST and attaches scope information to it
- * Creates a ScopeManager and assigns it to ast.scopeManager
+ * Checks if a function has no body (interface or abstract function)
+ * @param {ASTNode} fn - Function definition node
+ * @returns {boolean} True if function has no body
+ */
+function hasNoBody(fn) {
+  return fn.body === null
+}
+
+/**
+ * Checks if a function has an empty block body
+ * @param {ASTNode} fn - Function definition node
+ * @returns {boolean} True if function has empty body
+ */
+function hasEmptyBody(fn) {
+  if (!fn.body) return false
+  return (
+    fn.body.type === 'Block' && Array.isArray(fn.body.statements) && fn.body.statements.length === 0
+  )
+}
+
+/**
+ * Checks if a variable declaration is a return parameter
+ * @param {ASTNode} node - Variable declaration node
+ * @returns {boolean} True if node is a return parameter
+ */
+function isReturnParameter(node) {
+  const fn = findParentFunction(node)
+  if (!fn || !fn.returnParameters) return false
+  return fn.returnParameters.includes(node)
+}
+
+/**
+ * Checks if an identifier is being used in its own import declaration
+ * (e.g. the 'A' in 'import {A} from "./A.sol"')
+ * @param {ASTNode} idNode - Identifier node
+ * @returns {boolean} True if identifier is part of its own import
+ */
+function isImportDirectiveSelfReference(idNode) {
+  let cur = idNode.parent
+  while (cur) {
+    if (cur.type === 'ImportDirective') {
+      return true
+    }
+    // Stop if we hit a scope-creating node
+    if (
+      cur.type === 'Block' ||
+      cur.type === 'FunctionDefinition' ||
+      cur.type === 'ContractDefinition'
+    ) {
+      return false
+    }
+    cur = cur.parent
+  }
+  return false
+}
+
+/**
+ * Finds the nearest function definition containing this node
+ * @param {ASTNode} node - Starting node
+ * @returns {ASTNode|null} Parent function node or null if not in a function
+ */
+function findParentFunction(node) {
+  while (node) {
+    if (node.type === 'FunctionDefinition') {
+      return node
+    }
+    node = node.parent
+  }
+  return null
+}
+
+/**
+ * Checks if an identifier node is part of its own declaration
+ * @param {ASTNode} idNode - Identifier node
+ * @returns {boolean} True if identifier is being declared
+ */
+function isPartOfDeclaration(idNode) {
+  const p = idNode.parent
+  if (!p) return false
+
+  // Handle normal variable declarations
+  if (p.type === 'VariableDeclaration' && p.name === idNode.name) {
+    return true
+  }
+
+  // Handle assembly let declarations
+  if (p.type === 'AssemblyLocalDefinition') {
+    return p.names.some((n) => n.type === 'Identifier' && n.name === idNode.name)
+  }
+
+  return false
+}
+
+/**
+ * Attaches scope information to an AST
  * @param {ASTNode} ast - The AST to analyze
- * @returns {ASTNode} The AST with scope information attached
+ * @returns {ASTNode} The AST with attached scope information
  */
 function attachScopes(ast) {
   // Parent references are set up by astParents(ast) invocation upstream
   const scopeManager = new ScopeManager()
 
-  const visitor = {
-    // Create scopes
+  visit(ast, {
+    // Create scopes for all major structural elements
     SourceUnit(node) {
       scopeManager.addScope(node)
     },
@@ -107,71 +214,233 @@ function attachScopes(ast) {
     },
 
     FunctionDefinition(node) {
-      // Only create scope if it's not a function declaration
-      if (node.body !== null) {
-        scopeManager.addScope(node)
+      if (!hasNoBody(node)) {
+        const scope = scopeManager.addScope(node)
+
+        // Special handling for constructor modifiers
+        // Track usage of contract names in inheritance list
+        if (node.isConstructor && node.modifiers?.length) {
+          node.modifiers.forEach((mod) => {
+            if (mod.name) {
+              const namePart = mod.name.split('.')[0]
+              let sc = scope
+              while (sc) {
+                if (sc.trackUsage(namePart)) break
+                const p = sc.node?.parent
+                sc = p ? scopeManager.getScope(p) : null
+              }
+            }
+          })
+        }
       }
     },
 
     Block(node) {
-      // Don't create redundant scopes for function body blocks
-      const isFunctionBody = node.parent?.type === 'FunctionDefinition' && node.parent.body === node
-      if (!isFunctionBody) {
-        scopeManager.addScope(node)
+      // Skip function body blocks as they share scope with function parameters
+      const fn = node.parent
+      if (fn?.type === 'FunctionDefinition' && fn.body === node) {
+        return
+      }
+      scopeManager.addScope(node)
+    },
+
+    // Special handling for inline assembly
+    InlineAssemblyStatement(node) {
+      const trackIdentifierUsage = (id) => {
+        if (id.type === 'Identifier') {
+          let sc = scopeManager.getScope(id)
+          while (sc) {
+            if (sc.trackUsage(id.name)) break
+            const p = sc.node?.parent
+            sc = p ? scopeManager.getScope(p) : null
+          }
+        }
+      }
+
+      // Recursively visit assembly nodes to track identifier usage
+      const visit = (n) => {
+        if (!n) return
+
+        if (n.type === 'AssemblyLocalDefinition') {
+          // Track expression (right side) of assembly let statements
+          if (n.expression && n.expression.type === 'Identifier') {
+            trackIdentifierUsage(n.expression)
+          }
+        } else if (n.type === 'Identifier') {
+          trackIdentifierUsage(n)
+        }
+
+        // Visit all array children
+        if (Array.isArray(n)) {
+          n.forEach(visit)
+        }
+        // Visit operations in assembly blocks
+        else if (n.type === 'AssemblyBlock' && Array.isArray(n.operations)) {
+          n.operations.forEach(visit)
+        }
+        // Visit other object properties recursively
+        else if (typeof n === 'object') {
+          Object.values(n).forEach(visit)
+        }
+      }
+
+      visit(node.body)
+    },
+
+    // Track imported names in the source unit scope
+    ImportDirective(node) {
+      let top = node
+      while (top && top.type !== 'SourceUnit') {
+        top = top.parent
+      }
+      const sourceScope = top ? scopeManager.getScope(top) : null
+      if (!sourceScope) return
+
+      // Handle unit alias (import "..." as A)
+      if (node.unitAliasIdentifier) {
+        sourceScope.addVariable(node.unitAliasIdentifier, node.unitAliasIdentifier.name)
+      } else if (node.unitAlias) {
+        sourceScope.addVariable(node, node.unitAlias)
+      }
+
+      // Handle symbol aliases (import {A as B} from "...")
+      if (node.symbolAliasesIdentifiers) {
+        for (const [origId, aliasId] of node.symbolAliasesIdentifiers) {
+          const realId = aliasId || origId
+          sourceScope.addVariable(realId, realId.name)
+        }
       }
     },
 
-    ImportDirective(node) {
+    // Ignore state variables in unused checks
+    StateVariableDeclaration(node) {
       const scope = scopeManager.getScope(node)
       if (!scope) return
-
-      if (node.unitAlias) {
-        scope.addVariable(node.unitAliasIdentifier, node.unitAlias)
-      }
-      if (node.symbolAliases) {
-        node.symbolAliasesIdentifiers.forEach(([origId, aliasId]) => {
-          const id = aliasId || origId
-          scope.addVariable(id, id.name)
-        })
+      for (const v of node.variables) {
+        if (v && v.name) {
+          scope.addVariable(v, v.name, { ignore: false })
+        }
       }
     },
 
     VariableDeclaration(node) {
       const scope = scopeManager.getScope(node)
-      if (scope) {
-        scope.addVariable(node, node.name)
+      if (!scope) return
+
+      // Ignore state variables
+      if (node.isStateVar) {
+        scope.addVariable(node, node.name, { ignore: true })
+        return
+      }
+
+      const fn = findParentFunction(node)
+
+      // Ignore parameters in interface functions
+      if (fn && hasNoBody(fn)) {
+        scope.addVariable(node, node.name, { ignore: true })
+        return
+      }
+
+      // Ignore parameters in empty implementations (except return parameters)
+      if (fn && hasEmptyBody(fn) && !isReturnParameter(node)) {
+        scope.addVariable(node, node.name, { ignore: true })
+        return
+      }
+
+      scope.addVariable(node, node.name)
+    },
+
+    // Track variables declared in variable declaration statements
+    VariableDeclarationStatement(node) {
+      const scope = scopeManager.getScope(node)
+      if (!scope) return
+      for (const v of node.variables) {
+        if (!v) continue
+        scope.addVariable(v, v.name)
       }
     },
 
+    // Track assembly local variables
+    AssemblyLocalDefinition(node) {
+      const scope = scopeManager.getScope(node)
+      if (!scope) return
+      for (const v of node.names) {
+        if (v.type === 'Identifier') {
+          scope.addVariable(v, v.name)
+        }
+      }
+    },
+
+    // Track usage of library names in using declarations
+    UsingForDeclaration(node) {
+      const scope = scopeManager.getScope(node)
+      if (!scope) return
+
+      if (node.libraryName) {
+        let cur = scope
+        while (cur) {
+          if (cur.trackUsage(node.libraryName)) break
+          const p = cur.node?.parent
+          cur = p ? scopeManager.getScope(p) : null
+        }
+      }
+
+      // Track usage of function names in using declarations
+      if (node.functions) {
+        for (const fnStr of node.functions) {
+          const first = fnStr.split('.')[0]
+          let cur = scope
+          while (cur) {
+            if (cur.trackUsage(first)) break
+            const p = cur.node?.parent
+            cur = p ? scopeManager.getScope(p) : null
+          }
+        }
+      }
+    },
+
+    // Track usage of user-defined types
+    UserDefinedTypeName(node) {
+      const firstPart = node.namePath.split('.')[0]
+      let sc = scopeManager.getScope(node)
+      while (sc) {
+        if (sc.trackUsage(firstPart)) break
+        const p = sc.node?.parent
+        sc = p ? scopeManager.getScope(p) : null
+      }
+    },
+
+    // Track usage of identifiers in assembly calls
+    AssemblyCall(node) {
+      if (node.arguments.length === 0) {
+        let sc = scopeManager.getScope(node)
+        while (sc) {
+          if (sc.trackUsage(node.functionName)) break
+          const p = sc.node?.parent
+          sc = p ? scopeManager.getScope(p) : null
+        }
+      }
+    },
+
+    // Track general identifier usage
     Identifier(node) {
-      // Skip identifiers that are part of declarations
+      // Skip identifiers that are being declared
       if (isPartOfDeclaration(node)) return
+      // Skip identifiers in their own import statement
+      if (isImportDirectiveSelfReference(node)) return
 
       const name = node.name
-
-      // Track usage up the scope chain
-      let scope = scopeManager.getScope(node)
-      while (scope) {
-        if (scope.trackUsage(name)) {
+      let sc = scopeManager.getScope(node)
+      while (sc) {
+        if (sc.trackUsage(name)) {
           break
         }
-        scope = scope.node.parent ? scopeManager.getScope(scope.node.parent) : null
+        const p = sc.node?.parent
+        sc = p ? scopeManager.getScope(p) : null
       }
     },
-  }
+  })
 
-  function isPartOfDeclaration(node) {
-    const parent = node.parent
-    if (!parent) return false
-
-    if (parent.type === 'VariableDeclaration' && parent.name === node.name) {
-      return true
-    }
-
-    return false
-  }
-
-  visit(ast, visitor)
   ast.scopeManager = scopeManager
   return ast
 }

--- a/lib/common/scope-manager.js
+++ b/lib/common/scope-manager.js
@@ -1,0 +1,94 @@
+const _ = require('lodash')
+
+// TODO: docs
+class ScopeManager {
+  constructor() {
+    this.scopes = new Map()
+  }
+
+  addScope(node) {
+    const scope = new Scope(node)
+    this.scopes.set(node, scope)
+    return scope
+  }
+
+  getScope(node) {
+    // TODO: findScopeNode implementation
+    return this.scopes.get(this.findScopeNode(node))
+  }
+}
+
+class Scope {
+  constructor(node) {
+    this.node = node
+    this.variables = new Map()
+  }
+
+  addVariable(node, name) {
+    if (!this.variables.has(name)) {
+      this.variables.set(name, { node, usages: 0 })
+    }
+  }
+
+  // TODO: functions to track variable usage
+}
+
+function attachScopes(ast) {
+  const scopeManager = new ScopeManager()
+
+  if (ast.type === 'SourceUnit') {
+    scopeManager.addScope(ast)
+  }
+
+  const visitor = {
+    ContractDefinition(node) {
+      scopeManager.addScope(node)
+    },
+
+    FunctionDefinition(node) {
+      if (node.body) {
+        scopeManager.addScope(node)
+      }
+    },
+
+    Block(node) {
+      const isFunctionBody = node.parent?.type === 'FunctionDefinition'
+      if (!isFunctionBody) {
+        scopeManager.addScope(node)
+      }
+    },
+
+    // TODO: Handle aliased imports and symbol aliases
+
+    VariableDeclaration(node) {
+      // TODO: Add variable to the correct scope
+    },
+  }
+
+  // Traverse AST and attach scopes
+  function visit(node) {
+    if (!node || typeof node !== 'object') return
+
+    if (visitor[node.type]) {
+      visitor[node.type](node)
+    }
+
+    Object.keys(node).forEach(key => {
+      const child = node[key]
+      if (Array.isArray(child)) {
+        child.forEach(item => visit(item))
+      } else {
+        visit(child)
+      }
+    })
+  }
+
+  visit(ast)
+
+  // Attach scope manager to AST
+  ast.scopeManager = scopeManager
+
+  return ast
+}
+
+module.exports = { ScopeManager, Scope, attachScopes }

--- a/lib/common/scope-manager.js
+++ b/lib/common/scope-manager.js
@@ -1,94 +1,186 @@
 const _ = require('lodash')
+const parser = require('@solidity-parser/parser')
 
-// TODO: docs
+const { visit } = parser
+
+/**
+ * Manages lexical scoping for a Solidity AST
+ * Used to track variable declarations and their usage across different scopes
+ */
 class ScopeManager {
   constructor() {
     this.scopes = new Map()
   }
 
+  /**
+   * Creates a new scope for an AST node
+   * @param {ASTNode} node - The AST node to create a scope for
+   * @returns {Scope} The newly created scope
+   */
   addScope(node) {
     const scope = new Scope(node)
     this.scopes.set(node, scope)
     return scope
   }
 
+  /**
+   * Gets the scope that contains a given node
+   * @param {ASTNode} node - The AST node to find the scope for
+   * @returns {Scope|undefined} The containing scope, or undefined if none exists
+   */
   getScope(node) {
-    // TODO: findScopeNode implementation
     return this.scopes.get(this.findScopeNode(node))
+  }
+
+  findScopeNode(node) {
+    let current = node
+    while (current && !this.scopes.has(current)) {
+      current = current.parent
+    }
+    return current
   }
 }
 
+/**
+ * Represents a single lexical scope in the code
+ * Tracks variables declared in this scope and their usage
+ */
 class Scope {
   constructor(node) {
     this.node = node
     this.variables = new Map()
   }
 
+  /**
+   * Adds a variable declaration to this scope
+   * @param {ASTNode} node - The AST node representing the variable declaration
+   * @param {string} name - The name of the variable
+   */
   addVariable(node, name) {
     if (!this.variables.has(name)) {
       this.variables.set(name, { node, usages: 0 })
     }
   }
 
-  // TODO: functions to track variable usage
-}
-
-function attachScopes(ast) {
-  const scopeManager = new ScopeManager()
-
-  if (ast.type === 'SourceUnit') {
-    scopeManager.addScope(ast)
+  /**
+   * Records a usage of a variable in this scope
+   * @param {string} name - The name of the variable used
+   * @returns {boolean} Whether the variable exists in this scope
+   */
+  trackUsage(name) {
+    const variable = this.variables.get(name)
+    if (variable) {
+      variable.usages++
+      return true
+    }
+    return false
   }
 
+  hasVariable(name) {
+    return this.variables.has(name)
+  }
+
+  getUnusedVariables() {
+    return Array.from(this.variables.entries())
+      .filter(([, info]) => info.usages === 0)
+      .map(([name, info]) => ({ name, node: info.node }))
+  }
+}
+
+/**
+ * Analyzes an AST and attaches scope information to it
+ * Creates a ScopeManager and assigns it to ast.scopeManager
+ * @param {ASTNode} ast - The AST to analyze
+ * @returns {ASTNode} The AST with scope information attached
+ */
+function attachScopes(ast) {
+  // Parent references are set up by astParents(ast) invocation upstream
+  const scopeManager = new ScopeManager()
+
   const visitor = {
+    // Create scopes
+    SourceUnit(node) {
+      scopeManager.addScope(node)
+    },
+
     ContractDefinition(node) {
       scopeManager.addScope(node)
     },
 
     FunctionDefinition(node) {
-      if (node.body) {
+      // Only create scope if it's not a function declaration
+      if (node.body !== null) {
         scopeManager.addScope(node)
       }
     },
 
     Block(node) {
-      const isFunctionBody = node.parent?.type === 'FunctionDefinition'
+      // Don't create redundant scopes for function body blocks
+      const isFunctionBody = node.parent?.type === 'FunctionDefinition' && node.parent.body === node
       if (!isFunctionBody) {
         scopeManager.addScope(node)
       }
     },
 
-    // TODO: Handle aliased imports and symbol aliases
+    ImportDirective(node) {
+      const scope = scopeManager.getScope(node)
+      if (!scope) return
+
+      if (node.unitAlias) {
+        scope.addVariable(node.unitAliasIdentifier, node.unitAlias)
+      }
+      if (node.symbolAliases) {
+        node.symbolAliasesIdentifiers.forEach(([origId, aliasId]) => {
+          const id = aliasId || origId
+          scope.addVariable(id, id.name)
+        })
+      }
+    },
 
     VariableDeclaration(node) {
-      // TODO: Add variable to the correct scope
+      if (!node.name) return
+      const scope = scopeManager.getScope(node)
+      if (scope) {
+        scope.addVariable(node, node.name)
+      }
+    },
+
+    Identifier(node) {
+      // Skip identifiers that are part of declarations
+      if (isPartOfDeclaration(node)) return
+
+      const name = node.name
+      if (!name) return
+
+      // Track usage up the scope chain
+      let scope = scopeManager.getScope(node)
+      while (scope) {
+        if (scope.hasVariable(name) && scope.trackUsage(name)) {
+          break
+        }
+        scope = scope.node.parent ? scopeManager.getScope(scope.node.parent) : null
+      }
     },
   }
 
-  // Traverse AST and attach scopes
-  function visit(node) {
-    if (!node || typeof node !== 'object') return
+  function isPartOfDeclaration(node) {
+    const parent = node.parent
+    if (!parent) return false
 
-    if (visitor[node.type]) {
-      visitor[node.type](node)
+    if (parent.type === 'VariableDeclaration' && parent.name === node.name) {
+      return true
     }
 
-    Object.keys(node).forEach(key => {
-      const child = node[key]
-      if (Array.isArray(child)) {
-        child.forEach(item => visit(item))
-      } else {
-        visit(child)
-      }
-    })
+    return false
   }
 
-  visit(ast)
-
-  // Attach scope manager to AST
+  visit(ast, visitor)
   ast.scopeManager = scopeManager
-
   return ast
 }
 
-module.exports = { ScopeManager, Scope, attachScopes }
+module.exports = {
+  ScopeManager,
+  Scope,
+  attachScopes,
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ const ruleFixer = require('./rule-fixer')
 const Reporter = require('./reporter')
 const TreeListener = require('./tree-listener')
 const checkers = require('./rules/index')
+const { attachScopes } = require('./common/scope-manager')
 
 function parseInput(inputStr) {
   try {
@@ -49,6 +50,7 @@ function processStr(inputStr, config = {}, fileName = '') {
   const listener = new TreeListener(checkers(reporter, config, inputStr, tokens, fileName))
 
   astParents(ast)
+  attachScopes(ast)
   parser.visit(ast, listener)
 
   return reporter

--- a/lib/index.js
+++ b/lib/index.js
@@ -97,4 +97,4 @@ function fixStr(str, report) {
   return applyFixes(fixes, str)
 }
 
-module.exports = { processPath, processFile, processStr, fixStr }
+module.exports = { processPath, processFile, processStr, fixStr, parseInput }

--- a/lib/rules/best-practises/no-unused-vars.js
+++ b/lib/rules/best-practises/no-unused-vars.js
@@ -69,7 +69,7 @@ class NoUnusedVarsChecker extends BaseChecker {
 
   /**
    * We do the @inheritdoc usage detection here.
-   * Once done, we then gather the scope’s unused vars and report them.
+   * Once done, we then gather the scope's unused vars and report them.
    */
 
   'SourceUnit:exit'(node) {
@@ -156,19 +156,22 @@ class NoUnusedVarsChecker extends BaseChecker {
     }
   }
 
+  /**
+   * Gets the nearest valid scope for a given AST node by traversing up the tree
+   * @param {ASTNode} node - The AST node to find scope for
+   * @returns {Scope|null} The nearest valid scope or null if none found
+   */
   _getScope(node) {
     if (!node) return null
 
-    let top = node
-    while (top.parent) {
-      top = top.parent
+    // Traverse up until we find a node with a valid scopeManager
+    let current = node
+    while (current) {
+      if (current.scopeManager) {
+        return current.scopeManager.getScope(node)
+      }
+      current = current.parent
     }
-
-    if (!top.scopeManager) {
-      return null
-    }
-
-    return top.scopeManager.getScope(node)
   }
 }
 

--- a/lib/rules/best-practises/no-unused-vars.js
+++ b/lib/rules/best-practises/no-unused-vars.js
@@ -1,9 +1,6 @@
-const _ = require('lodash')
 const BaseChecker = require('../base-checker')
-const TreeTraversing = require('../../common/tree-traversing')
-const { contractWith, funcWith } = require('../../../test/common/contract-builder')
 
-const { findParentType, findFirstParent } = new TreeTraversing()
+const { contractWith, funcWith } = require('../../../test/common/contract-builder')
 
 const ruleId = 'no-unused-vars'
 const meta = {
@@ -70,227 +67,108 @@ class NoUnusedVarsChecker extends BaseChecker {
     this.tokens = tokens
   }
 
-  // imported variables need a scope to be tracked in
-  SourceUnit(node) {
-    VarUsageScope.activate(node)
-  }
+  /**
+   * We do the @inheritdoc usage detection here.
+   * Once done, we then gather the scope’s unused vars and report them.
+   */
 
   'SourceUnit:exit'(node) {
     // get inheritdoc statements from the lexed (but not parsed) input
-    const keywords = this.tokens.filter((it) => it.type === 'Keyword')
-    const inheritdocStatements = keywords.filter(
-      ({ value }) => /^\/\/\/ *@inheritdoc/.test(value) || /^\/\*\* *@inheritdoc/.test(value)
+    const keywords = this.tokens.filter((t) => t.type === 'Keyword')
+    const inheritdocs = keywords.filter((k) =>
+      /^\/\/\/ *@inheritdoc|^\/\*\* *@inheritdoc/.test(k.value)
     )
     // mark inheritdoc'd names as used in the SourceUnit scope, since it only makes
     // sense to extend the documentation of a name defined somewhere else.
     // this doesn't break since all items that can have natspec (from the language docs):
     // > Documentation is inserted above each contract, interface, library, function, and event
     // cannot be inside a block
-    inheritdocStatements.forEach(({ value }) => {
+    inheritdocs.forEach(({ value }) => {
       const match = value.match(/@inheritdoc *([a-zA-Z0-9_]*)/)
       if (match && match[1]) {
-        node.scope.trackVarUsage(match[1])
+        this._trackUsageUp(node, match[1])
       }
     })
 
-    node.scope.unusedVariables().forEach(this._error.bind(this))
-  }
-
-  Block(node) {
-    if (node.parent?.type === 'FunctionDefinition') {
-      return
-    }
-    VarUsageScope.activate(node)
+    this._reportUnused(node)
   }
 
   'Block:exit'(node) {
-    if (node.parent?.type === 'FunctionDefinition') {
-      return
-    }
-    node.scope.unusedVariables().forEach(this._error.bind(this))
+    if (node.parent?.type === 'FunctionDefinition') return
+    this._reportUnused(node)
   }
 
   'FunctionDefinition:exit'(node) {
-    node.scope.unusedVariables().forEach(this._error.bind(this))
-  }
+    if (!node.body) return // Skip functions without bodies
 
-  VariableDeclarationStatement(node) {
-    // skip the definitions of function parameters, they're taken care of by
-    // Block visitor
-    if (node.parent.type === 'FunctionDefinition') return
-    node.variables.forEach((variable) => this._addVariable(variable))
-  }
+    // Handle return parameters
+    if (node.returnParameters) {
+      const hasReturn = node.body.statements.some((st) => st.type === 'ReturnStatement')
 
-  AssemblyLocalDefinition(node) {
-    node.names.forEach((variable) => this._addVariable(variable))
-  }
-
-  FunctionDefinition(node) {
-    // don't apply this rule for function _declarations_ as parameters can't
-    // really be used, but giving them names aids in documentation.
-    if (node.body === null) {
-      return
+      if (hasReturn) {
+        // Mark named return params as used
+        for (const param of node.returnParameters) {
+          if (param.name) {
+            this._trackUsageUp(node, param.name)
+          }
+        }
+      }
     }
-    if (node.isConstructor) {
-      // track usage of extended contracts in member initialization list
-      node.modifiers.forEach((it) => this._trackVarUsage(it))
+
+    // Handle assembly usage of parameters
+    const hasAssembly = node.body.statements.some((st) => st.type === 'InlineAssemblyStatement')
+
+    if (hasAssembly) {
+      // Parameters used in assembly are considered used
+      for (const param of node.parameters || []) {
+        if (param.name) {
+          const scope = this._getScope(node)
+          if (scope) {
+            scope.trackUsage(param.name)
+          }
+        }
+      }
     }
-    VarUsageScope.activate(node)
-    // filters 'payable' keyword as name when defining function like this:
-    // function foo(address payable) public view {}. I believe this is a parser limitation
-    node.parameters
-      .filter((parameter) => {
-        if (
-          parameter.typeName.name === 'address' &&
-          parameter.typeName.stateMutability === null &&
-          parameter.name === 'payable'
-        )
-          return null
-        else return parameter.name
-      })
-      .forEach(({ name, typeName }) => {
-        node.scope.addVar(typeName, name)
-      })
-    node.modifiers.forEach((modifier) =>
-      modifier.arguments.forEach((argument) => this._trackVarUsage(argument))
-    )
+
+    this._reportUnused(node)
   }
 
-  UserDefinedTypeName(node) {
-    this._trackVarUsage(node, true)
-  }
-
-  UsingForDeclaration(node) {
-    if (node.libraryName) {
-      this._trackVarUsage(node)
-    }
-    // It's okay to not search upwards for the scope containing it, since it's
-    // defined at the grammar level that using-for directives can only be childs
-    // of source units or contract definitions
-    const scope = VarUsageScope.of(node)
-    // the name can be either the imported thing, or a member access of it
-    node.functions.forEach((it) => scope.trackVarUsage(it.split('.')[0]))
-  }
-
-  Identifier(node) {
-    this._trackVarUsage(node)
-  }
-
-  ImportDirective(node) {
-    if (node.unitAlias) {
-      node.unitAliasIdentifier.parent = node
-      this._addVariable(node, node.unitAliasIdentifier.name)
-    } else {
-      node.symbolAliasesIdentifiers.forEach((it) => {
-        const idNode = it[1] || it[0]
-        // I have to define the parent manually because of a bug with ast-parents
-        // see #119
-        Object.defineProperty(idNode, 'parent', {
-          value: node,
-          configurable: true,
-          enumerable: false,
-          writable: true,
-        })
-        this._addVariable(idNode)
-      })
+  _reportUnused(node) {
+    const scope = this._getScope(node)
+    if (!scope) return
+    for (const { name, node: varNode } of scope.getUnusedVariables()) {
+      this.warn(varNode, `Variable "${name}" is unused`)
     }
   }
 
-  AssemblyCall(node) {
-    const firstChild = node.arguments.length === 0 && node
-
-    if (firstChild) {
-      firstChild.name = firstChild.functionName
-      this._trackVarUsage(firstChild)
+  /**
+   * `_trackVarUsage` recurses up scopes
+   */
+  _trackUsageUp(node, name) {
+    // If we detect name is an import alias but no real references, skip
+    let sc = this._getScope(node)
+    while (sc) {
+      if (sc.trackUsage(name)) {
+        return
+      }
+      const parent = sc.node && sc.node.parent
+      sc = parent ? this._getScope(parent) : null
     }
   }
 
-  _addVariable(idNode, customName) {
-    const scope = VarUsageScope.of(idNode)
+  _getScope(node) {
+    if (!node) return null
 
-    if (idNode && scope) {
-      scope.addVar(idNode, customName || idNode.name)
+    let top = node
+    while (top.parent) {
+      top = top.parent
     }
-  }
 
-  _trackVarUsage(node, trackInsideVarDeclaration = false) {
-    if (!trackInsideVarDeclaration && this._isVarDeclaration(node)) return
-    // nodes passed here can be of various types, and have its 'name' in different fields
-    // plus the name itself can be a member access of the name that's actually defined
-    const name = (node.name || node.namePath || node.libraryName).split('.')[0]
-    // if I can't find the name here, search upwards for a scope that might
-    // have it
-    while (!VarUsageScope.of(node).hasVar(name)) {
-      node = node.parent
+    if (!top.scopeManager) {
+      return null
     }
-    VarUsageScope.of(node).trackVarUsage(name)
-  }
 
-  _error({ name, node }) {
-    this.warn(node, `Variable "${name}" is unused`)
-  }
-
-  _isVarDeclaration(node) {
-    const importDirective = findParentType(node, 'ImportDirective')
-    const variableDeclaration = findParentType(node, 'VariableDeclaration')
-    const identifierList = findParentType(node, 'IdentifierList')
-    const parameterList = findParentType(node, 'ParameterList')
-    const assemblyLocalDefinition = findParentType(node, 'AssemblyLocalDefinition')
-
-    // otherwise `let t := a` doesn't track usage of `a`
-    const isAssemblyLocalDefinition =
-      assemblyLocalDefinition &&
-      assemblyLocalDefinition.names &&
-      assemblyLocalDefinition.names.includes(node)
-
-    return !!(
-      variableDeclaration ||
-      identifierList ||
-      parameterList ||
-      isAssemblyLocalDefinition ||
-      importDirective
-    )
-  }
-}
-
-class VarUsageScope {
-  static of(node) {
-    return findFirstParent(node, (it) => !!it.scope)?.scope
-  }
-
-  static activate(node) {
-    node.scope = new VarUsageScope()
-  }
-
-  static isActivated(node) {
-    return !!node.scope
-  }
-
-  constructor() {
-    this.vars = {}
-  }
-
-  addVar(node, name) {
-    this.vars[name] = { node, usage: 0 }
-  }
-
-  hasVar(name) {
-    return this.vars[name] !== undefined
-  }
-
-  trackVarUsage(name) {
-    const curVar = this.vars[name]
-
-    if (curVar) {
-      curVar.usage += 1
-    }
-  }
-
-  unusedVariables() {
-    return _(this.vars)
-      .pickBy((val) => val.usage === 0)
-      .map((info, varName) => ({ name: varName, node: info.node }))
-      .value()
+    return top.scopeManager.getScope(node)
   }
 }
 

--- a/lib/rules/best-practises/no-unused-vars.js
+++ b/lib/rules/best-practises/no-unused-vars.js
@@ -75,7 +75,7 @@ class NoUnusedVarsChecker extends BaseChecker {
   'SourceUnit:exit'(node) {
     // get inheritdoc statements from the lexed (but not parsed) input
     const keywords = this.tokens.filter((t) => t.type === 'Keyword')
-    const inheritdocs = keywords.filter((k) =>
+    const inheritdocStatements = keywords.filter((k) =>
       /^\/\/\/ *@inheritdoc|^\/\*\* *@inheritdoc/.test(k.value)
     )
     // mark inheritdoc'd names as used in the SourceUnit scope, since it only makes
@@ -83,7 +83,7 @@ class NoUnusedVarsChecker extends BaseChecker {
     // this doesn't break since all items that can have natspec (from the language docs):
     // > Documentation is inserted above each contract, interface, library, function, and event
     // cannot be inside a block
-    inheritdocs.forEach(({ value }) => {
+    inheritdocStatements.forEach(({ value }) => {
       const match = value.match(/@inheritdoc *([a-zA-Z0-9_]*)/)
       if (match && match[1]) {
         this._trackUsageUp(node, match[1])

--- a/test/common/scope-manager.js
+++ b/test/common/scope-manager.js
@@ -1,16 +1,9 @@
 /* eslint-disable no-unused-expressions */
 // We disable no-unused-expressions because chai does not have lint-friendly terminating assertions
 const { expect } = require('chai')
-const parser = require('@solidity-parser/parser')
 const astParents = require('ast-parents')
 const { ScopeManager, Scope, attachScopes } = require('../../lib/common/scope-manager')
-
-/**
- * Helper to parse code
- */
-function parse(code) {
-  return parser.parse(code, { loc: true, range: true })
-}
+const { parseInput } = require('../../lib/index')
 
 describe('ScopeManager', () => {
   let scopeManager
@@ -55,7 +48,7 @@ describe('Scope', () => {
 
   describe('addVariable', () => {
     it('should track variable declarations correctly with correct node and name', () => {
-      const ast = parse('contract C { function f() public { uint x; } }')
+      const ast = parseInput('contract C { function f() public { uint x; } }')
       astParents(ast)
       attachScopes(ast)
 
@@ -73,7 +66,7 @@ describe('Scope', () => {
     })
 
     it('should handle multiple variable declarations', () => {
-      const ast = parse('contract C { function f() public { uint x; uint y; } }')
+      const ast = parseInput('contract C { function f() public { uint x; uint y; } }')
       astParents(ast)
       attachScopes(ast)
 
@@ -97,7 +90,7 @@ describe('Scope', () => {
     })
 
     it('should accurately reflect variable presence using hasVariable', () => {
-      const ast = parse('contract C { function f() public { uint x; } }')
+      const ast = parseInput('contract C { function f() public { uint x; } }')
       astParents(ast)
       attachScopes(ast)
 
@@ -168,7 +161,7 @@ describe('attachScopes', () => {
   describe('Scope Creation', () => {
     describe('SourceUnit', () => {
       it('should create scopes for SourceUnit', () => {
-        const ast = parse('contract C {}')
+        const ast = parseInput('contract C {}')
         astParents(ast)
         attachScopes(ast)
 
@@ -178,7 +171,7 @@ describe('attachScopes', () => {
 
     describe('ContractDefinition', () => {
       it('should create scopes for ContractDefinition', () => {
-        const ast = parse('contract C {}')
+        const ast = parseInput('contract C {}')
         astParents(ast)
         attachScopes(ast)
 
@@ -187,7 +180,7 @@ describe('attachScopes', () => {
       })
 
       it('should create scope for empty contract', () => {
-        const ast = parse('contract C {}')
+        const ast = parseInput('contract C {}')
         astParents(ast)
         attachScopes(ast)
 
@@ -196,7 +189,7 @@ describe('attachScopes', () => {
       })
 
       it('should create scope for interface', () => {
-        const ast = parse('interface I {}')
+        const ast = parseInput('interface I {}')
         astParents(ast)
         attachScopes(ast)
 
@@ -205,7 +198,7 @@ describe('attachScopes', () => {
       })
 
       it('should create scope for library', () => {
-        const ast = parse('library L {}')
+        const ast = parseInput('library L {}')
         astParents(ast)
         attachScopes(ast)
 
@@ -216,7 +209,7 @@ describe('attachScopes', () => {
 
     describe('FunctionDefinition', () => {
       it('should create scopes for FunctionDefinition with body', () => {
-        const ast = parse('contract C { function f() public {} }')
+        const ast = parseInput('contract C { function f() public {} }')
         astParents(ast)
         attachScopes(ast)
 
@@ -225,7 +218,7 @@ describe('attachScopes', () => {
       })
 
       it('should not create scopes for function declarations without body', () => {
-        const ast = parse('contract C { function f() public; }')
+        const ast = parseInput('contract C { function f() public; }')
         astParents(ast)
         attachScopes(ast)
 
@@ -236,7 +229,7 @@ describe('attachScopes', () => {
       })
 
       it('should create scope for function with empty body', () => {
-        const ast = parse('contract C { function f() public {} }')
+        const ast = parseInput('contract C { function f() public {} }')
         astParents(ast)
         attachScopes(ast)
 
@@ -245,7 +238,7 @@ describe('attachScopes', () => {
       })
 
       it('should not create scope for function declaration (null body)', () => {
-        const ast = parse('contract C { function f() public; }')
+        const ast = parseInput('contract C { function f() public; }')
         astParents(ast)
         attachScopes(ast)
 
@@ -256,7 +249,7 @@ describe('attachScopes', () => {
 
     describe('Block', () => {
       it('should create scopes for non-function-body blocks', () => {
-        const ast = parse('contract C { function f() public { if (true) { uint x; } } }')
+        const ast = parseInput('contract C { function f() public { if (true) { uint x; } } }')
         astParents(ast)
         attachScopes(ast)
 
@@ -265,7 +258,7 @@ describe('attachScopes', () => {
       })
 
       it('should not create redundant scope for function body blocks', () => {
-        const ast = parse('contract C { function f() public { uint x; } }')
+        const ast = parseInput('contract C { function f() public { uint x; } }')
         astParents(ast)
         attachScopes(ast)
 
@@ -278,7 +271,7 @@ describe('attachScopes', () => {
   describe('Variable Declarations and Usages', () => {
     describe('Import Declarations', () => {
       it('should correctly assign unitAliasIdentifier and unitAlias for import with unit alias', () => {
-        const ast = parse(`
+        const ast = parseInput(`
                 import "./A.sol" as AliasA;
     
                 contract C {
@@ -302,7 +295,7 @@ describe('attachScopes', () => {
       })
 
       it('should correctly assign symbolAliasesIdentifiers and symbolAliases for import with symbol aliases', () => {
-        const ast = parse(`
+        const ast = parseInput(`
                 import { Foo as Bar } from "./Foo.sol";
     
                 contract C {
@@ -326,7 +319,7 @@ describe('attachScopes', () => {
       })
 
       it('should track import declarations with unit alias', () => {
-        const ast = parse(`
+        const ast = parseInput(`
                 import "./A.sol" as AliasA;
     
                 contract C {
@@ -345,7 +338,7 @@ describe('attachScopes', () => {
       })
 
       it('should track import declarations with symbol aliases', () => {
-        const ast = parse(`
+        const ast = parseInput(`
                 import { Foo as Bar } from "./Foo.sol";
     
                 contract C {
@@ -365,7 +358,7 @@ describe('attachScopes', () => {
 
     describe('Variable Declarations', () => {
       it('should track variable declarations', () => {
-        const ast = parse('contract C { function f() public { uint x; } }')
+        const ast = parseInput('contract C { function f() public { uint x; } }')
         astParents(ast)
         attachScopes(ast)
 
@@ -383,7 +376,7 @@ describe('attachScopes', () => {
               x = 1;
             }
           }`
-        const ast = parse(code)
+        const ast = parseInput(code)
         astParents(ast)
         attachScopes(ast)
 
@@ -394,7 +387,7 @@ describe('attachScopes', () => {
 
     describe('Identifier Nodes', () => {
       it('should not track identifier nodes that are part of declarations', () => {
-        const ast = parse('contract C { uint x; }')
+        const ast = parseInput('contract C { uint x; }')
         astParents(ast)
         attachScopes(ast)
 

--- a/test/common/scope-manager.js
+++ b/test/common/scope-manager.js
@@ -1,0 +1,406 @@
+/* eslint-disable no-unused-expressions */
+// We disable no-unused-expressions because chai does not have lint-friendly terminating assertions
+const { expect } = require('chai')
+const parser = require('@solidity-parser/parser')
+const astParents = require('ast-parents')
+const { ScopeManager, Scope, attachScopes } = require('../../lib/common/scope-manager')
+
+/**
+ * Helper to parse code
+ */
+function parse(code) {
+  return parser.parse(code, { loc: true, range: true })
+}
+
+describe('ScopeManager', () => {
+  let scopeManager
+
+  beforeEach(() => {
+    scopeManager = new ScopeManager()
+  })
+
+  describe('addScope', () => {
+    it('should create and store a new scope for a node', () => {
+      const node = { type: 'SourceUnit' }
+      const scope = scopeManager.addScope(node)
+      expect(scope).to.be.instanceOf(Scope)
+      expect(scopeManager.scopes.get(node)).to.equal(scope)
+    })
+  })
+
+  describe('getScope and findScopeNode', () => {
+    it('should find the nearest scope up the AST tree', () => {
+      const parent = { type: 'SourceUnit' }
+      const child = { type: 'Identifier', parent }
+      const scope = scopeManager.addScope(parent)
+
+      expect(scopeManager.getScope(child)).to.equal(scope)
+    })
+
+    it('should return undefined when no scope exists', () => {
+      const node = { type: 'Identifier' }
+      expect(scopeManager.getScope(node)).to.be.undefined
+    })
+  })
+})
+
+describe('Scope', () => {
+  let scope
+  let node
+
+  beforeEach(() => {
+    node = { type: 'Block' }
+    scope = new Scope(node)
+  })
+
+  describe('addVariable', () => {
+    it('should track variable declarations correctly with correct node and name', () => {
+      const ast = parse('contract C { function f() public { uint x; } }')
+      astParents(ast)
+      attachScopes(ast)
+
+      const funcNode = ast.children[0].subNodes[0]
+      const funcScope = ast.scopeManager.getScope(funcNode)
+
+      expect(funcScope.hasVariable('x')).to.be.true
+
+      const variable = funcScope.variables.get('x')
+      expect(variable).to.exist
+
+      const varDeclaration = funcNode.body.statements[0].variables[0]
+      expect(variable.node).to.equal(varDeclaration)
+      expect(variable.node.name).to.equal('x')
+    })
+
+    it('should handle multiple variable declarations', () => {
+      const ast = parse('contract C { function f() public { uint x; uint y; } }')
+      astParents(ast)
+      attachScopes(ast)
+
+      const funcNode = ast.children[0].subNodes[0]
+      const funcScope = ast.scopeManager.getScope(funcNode)
+
+      expect(funcScope.hasVariable('x')).to.be.true
+      expect(funcScope.hasVariable('y')).to.be.true
+
+      const varDeclarationX = funcNode.body.statements[0].variables[0]
+      const varDeclarationY = funcNode.body.statements[1].variables[0]
+
+      const variableX = funcScope.variables.get('x')
+      const variableY = funcScope.variables.get('y')
+
+      expect(variableX.node).to.equal(varDeclarationX)
+      expect(variableX.node.name).to.equal('x')
+
+      expect(variableY.node).to.equal(varDeclarationY)
+      expect(variableY.node.name).to.equal('y')
+    })
+
+    it('should accurately reflect variable presence using hasVariable', () => {
+      const ast = parse('contract C { function f() public { uint x; } }')
+      astParents(ast)
+      attachScopes(ast)
+
+      const funcNode = ast.children[0].subNodes[0]
+      const funcScope = ast.scopeManager.getScope(funcNode)
+
+      expect(funcScope.hasVariable('x')).to.be.true
+      expect(funcScope.hasVariable('y')).to.be.false
+    })
+
+    it('should add a new variable to the scope', () => {
+      const varNode = { type: 'VariableDeclaration', name: 'x' }
+      scope.addVariable(varNode, 'x')
+      expect(scope.variables.has('x')).to.be.true
+      expect(scope.variables.get('x')).to.deep.equal({ node: varNode, usages: 0 })
+    })
+
+    it('should not overwrite existing variables', () => {
+      const varNode1 = { type: 'VariableDeclaration', name: 'x' }
+      const varNode2 = { type: 'VariableDeclaration', name: 'x' }
+      scope.addVariable(varNode1, 'x')
+      scope.addVariable(varNode2, 'x')
+      expect(scope.variables.get('x').node).to.equal(varNode1)
+    })
+  })
+
+  describe('trackUsage', () => {
+    it('should increment usage count and return true for existing variables', () => {
+      const varNode = { type: 'VariableDeclaration', name: 'x' }
+      scope.addVariable(varNode, 'x')
+      expect(scope.trackUsage('x')).to.be.true
+      expect(scope.variables.get('x')?.usages).to.equal(1)
+    })
+
+    it('should return false for non-existent variables', () => {
+      expect(scope.trackUsage('nonexistent')).to.be.false
+    })
+  })
+
+  describe('hasVariable', () => {
+    it('should return true for existing variables', () => {
+      const varNode = { type: 'VariableDeclaration', name: 'x' }
+      scope.addVariable(varNode, 'x')
+      expect(scope.hasVariable('x')).to.be.true
+    })
+
+    it('should return false for non-existent variables', () => {
+      expect(scope.hasVariable('nonexistent')).to.be.false
+    })
+  })
+
+  describe('getUnusedVariables', () => {
+    it('should return variables with zero usages', () => {
+      const var1 = { type: 'VariableDeclaration', name: 'x' }
+      const var2 = { type: 'VariableDeclaration', name: 'y' }
+      scope.addVariable(var1, 'x')
+      scope.addVariable(var2, 'y')
+      scope.trackUsage('x')
+
+      const unused = scope.getUnusedVariables()
+      expect(unused).to.have.lengthOf(1)
+      expect(unused[0]).to.deep.equal({ name: 'y', node: var2 })
+    })
+  })
+})
+
+describe('attachScopes', () => {
+  describe('Scope Creation', () => {
+    describe('SourceUnit', () => {
+      it('should create scopes for SourceUnit', () => {
+        const ast = parse('contract C {}')
+        astParents(ast)
+        attachScopes(ast)
+
+        expect(ast.scopeManager.getScope(ast)).to.exist
+      })
+    })
+
+    describe('ContractDefinition', () => {
+      it('should create scopes for ContractDefinition', () => {
+        const ast = parse('contract C {}')
+        astParents(ast)
+        attachScopes(ast)
+
+        const contract = ast.children[0]
+        expect(ast.scopeManager.getScope(contract)).to.exist
+      })
+
+      it('should create scope for empty contract', () => {
+        const ast = parse('contract C {}')
+        astParents(ast)
+        attachScopes(ast)
+
+        const contract = ast.children[0]
+        expect(ast.scopeManager.scopes.get(contract)).to.exist
+      })
+
+      it('should create scope for interface', () => {
+        const ast = parse('interface I {}')
+        astParents(ast)
+        attachScopes(ast)
+
+        const iface = ast.children[0]
+        expect(ast.scopeManager.scopes.get(iface)).to.exist
+      })
+
+      it('should create scope for library', () => {
+        const ast = parse('library L {}')
+        astParents(ast)
+        attachScopes(ast)
+
+        const lib = ast.children[0]
+        expect(ast.scopeManager.scopes.get(lib)).to.exist
+      })
+    })
+
+    describe('FunctionDefinition', () => {
+      it('should create scopes for FunctionDefinition with body', () => {
+        const ast = parse('contract C { function f() public {} }')
+        astParents(ast)
+        attachScopes(ast)
+
+        const func = ast.children[0].subNodes[0]
+        expect(ast.scopeManager.getScope(func)).to.exist
+      })
+
+      it('should not create scopes for function declarations without body', () => {
+        const ast = parse('contract C { function f() public; }')
+        astParents(ast)
+        attachScopes(ast)
+
+        // This is a function *declaration* (body = null), so no scope is created.
+        const func = ast.children[0].subNodes[0]
+        const immediateScope = ast.scopeManager.scopes.get(func)
+        expect(immediateScope).to.be.undefined
+      })
+
+      it('should create scope for function with empty body', () => {
+        const ast = parse('contract C { function f() public {} }')
+        astParents(ast)
+        attachScopes(ast)
+
+        const func = ast.children[0].subNodes[0]
+        expect(ast.scopeManager.scopes.get(func)).to.exist
+      })
+
+      it('should not create scope for function declaration (null body)', () => {
+        const ast = parse('contract C { function f() public; }')
+        astParents(ast)
+        attachScopes(ast)
+
+        const func = ast.children[0].subNodes[0]
+        expect(ast.scopeManager.scopes.get(func)).to.be.undefined
+      })
+    })
+
+    describe('Block', () => {
+      it('should create scopes for non-function-body blocks', () => {
+        const ast = parse('contract C { function f() public { if (true) { uint x; } } }')
+        astParents(ast)
+        attachScopes(ast)
+
+        const ifBlock = ast.children[0].subNodes[0].body.statements[0].trueBody
+        expect(ast.scopeManager.getScope(ifBlock)).to.exist
+      })
+
+      it('should not create redundant scope for function body blocks', () => {
+        const ast = parse('contract C { function f() public { uint x; } }')
+        astParents(ast)
+        attachScopes(ast)
+
+        const functionBody = ast.children[0].subNodes[0].body
+        expect(ast.scopeManager.scopes.get(functionBody)).to.be.undefined
+      })
+    })
+  })
+
+  describe('Variable Declarations and Usages', () => {
+    describe('Import Declarations', () => {
+      it('should correctly assign unitAliasIdentifier and unitAlias for import with unit alias', () => {
+        const ast = parse(`
+                import "./A.sol" as AliasA;
+    
+                contract C {
+                    AliasA.A aInstance;
+                }
+            `)
+        astParents(ast)
+        attachScopes(ast)
+
+        const contractC = ast.children.find(
+          (child) => child.type === 'ContractDefinition' && child.name === 'C'
+        )
+        const scope = ast.scopeManager.getScope(contractC)
+
+        expect(scope.hasVariable('aInstance')).to.be.true
+
+        const variable = scope.variables.get('aInstance')
+        expect(variable).to.exist
+        expect(variable.node.name).to.equal('aInstance')
+        expect(variable.node.typeName.namePath).to.equal('AliasA.A')
+      })
+
+      it('should correctly assign symbolAliasesIdentifiers and symbolAliases for import with symbol aliases', () => {
+        const ast = parse(`
+                import { Foo as Bar } from "./Foo.sol";
+    
+                contract C {
+                    Bar bInstance;
+                }
+            `)
+        astParents(ast)
+        attachScopes(ast)
+
+        const contractC = ast.children.find(
+          (child) => child.type === 'ContractDefinition' && child.name === 'C'
+        )
+        const scope = ast.scopeManager.getScope(contractC)
+
+        expect(scope.hasVariable('bInstance')).to.be.true
+
+        const variable = scope.variables.get('bInstance')
+        expect(variable).to.exist
+        expect(variable.node.name).to.equal('bInstance')
+        expect(variable.node.typeName.namePath).to.equal('Bar')
+      })
+
+      it('should track import declarations with unit alias', () => {
+        const ast = parse(`
+                import "./A.sol" as AliasA;
+    
+                contract C {
+                    AliasA.A aInstance;
+                }
+            `)
+        astParents(ast)
+        attachScopes(ast)
+
+        const contractC = ast.children.find(
+          (child) => child.type === 'ContractDefinition' && child.name === 'C'
+        )
+        const scope = ast.scopeManager.getScope(contractC)
+
+        expect(scope.hasVariable('aInstance')).to.be.true
+      })
+
+      it('should track import declarations with symbol aliases', () => {
+        const ast = parse(`
+                import { Foo as Bar } from "./Foo.sol";
+    
+                contract C {
+                    Bar bInstance;
+                }
+            `)
+        astParents(ast)
+        attachScopes(ast)
+
+        const contractC = ast.children.find(
+          (child) => child.type === 'ContractDefinition' && child.name === 'C'
+        )
+        const scope = ast.scopeManager.getScope(contractC)
+        expect(scope.hasVariable('bInstance')).to.be.true
+      })
+    })
+
+    describe('Variable Declarations', () => {
+      it('should track variable declarations', () => {
+        const ast = parse('contract C { function f() public { uint x; } }')
+        astParents(ast)
+        attachScopes(ast)
+
+        const funcScope = ast.scopeManager.getScope(ast.children[0].subNodes[0])
+        expect(funcScope.hasVariable('x')).to.be.true
+      })
+    })
+
+    describe('Variable Usages', () => {
+      it('should track variable usages up the scope chain', () => {
+        const code = `
+          contract C {
+            uint x;
+            function f() public {
+              x = 1;
+            }
+          }`
+        const ast = parse(code)
+        astParents(ast)
+        attachScopes(ast)
+
+        const contractScope = ast.scopeManager.getScope(ast.children[0])
+        expect(contractScope.variables.get('x')?.usages).to.equal(1)
+      })
+    })
+
+    describe('Identifier Nodes', () => {
+      it('should not track identifier nodes that are part of declarations', () => {
+        const ast = parse('contract C { uint x; }')
+        astParents(ast)
+        attachScopes(ast)
+
+        const contractScope = ast.scopeManager.getScope(ast.children[0])
+        expect(contractScope.variables.get('x')?.usages).to.equal(0)
+      })
+    })
+  })
+})


### PR DESCRIPTION
Closes #120 

Here is a brief summary of what I've done for adding scope info to the AST
1) Created scope-manager.js which handles the lexical scoping + tracking logic to prevent no-unused-vars from needing to modify the AST

Scope-manager.js has 100% test code coverage. However, I would recommend some performance testing before the release by checking with some repos with large amount of Solidity examples to find edge cases we haven't considered. Ideally for future work we would do an incremental migration of solhint to TypeScript, starting with scope-manager.js, to ensure that we not only cover 100% of the code but also all of the possible branches and ensure there are no edge cases that could cause an error and/or redundant guards. Note that in the JSDocs I've included the types of each function which should help with an incremental migration because these should be the accurate types (though currently they're not enforced)

2) Made no-unused-vars a smaller rule that does not modify the AST--we have 100% code coverage for no-unused-vars.js as well but I'd make the same recommendations as above

Future work:

- check that no other rules modify the AST

code-complexity.js and reentrancy.js at least

- no-shadowing rule https://github.com/solhint-community/solhint-community/issues/156